### PR TITLE
add LICENSE and copyright notices

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,10 @@
+MIT License
+
+Copyright (c) 2018 Antti Myyrä
+Copyright © 2019 Arrikto Inc.  All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OIDC AuthService
 
-This is a rewrite of the [ambassador-oidc-authservice](https://github.com/ajmyyra/ambassador-auth-oidc) project.
+This is a rewrite of the [ajmyyra/ambassador-auth-oidc](https://github.com/ajmyyra/ambassador-auth-oidc) project.
 
 An AuthService is an HTTP Server that an API Gateway (eg Ambassador, Envoy) asks if an incoming request is authorized.
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,3 +1,5 @@
+// Copyright © 2019 Arrikto Inc.  All Rights Reserved.
+
 package e2e
 
 import (

--- a/handlers.go
+++ b/handlers.go
@@ -1,3 +1,5 @@
+// Copyright © 2019 Arrikto Inc.  All Rights Reserved.
+
 package main
 
 import (

--- a/main.go
+++ b/main.go
@@ -1,3 +1,5 @@
+// Copyright © 2019 Arrikto Inc.  All Rights Reserved.
+
 package main
 
 import (

--- a/state.go
+++ b/state.go
@@ -1,9 +1,10 @@
+// Copyright © 2019 Arrikto Inc.  All Rights Reserved.
+
 package main
 
 import (
 	"github.com/gorilla/sessions"
 	"github.com/pkg/errors"
-	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"time"
@@ -63,14 +64,4 @@ func (s *state) save(store sessions.Store) (string, error) {
 		return "", errors.Wrap(err, "error trying to save session")
 	}
 	return c.Value, nil
-}
-
-func createNonce(length int) string {
-	nonceChars := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
-	var nonce = make([]rune, length)
-	for i := range nonce {
-		nonce[i] = nonceChars[rand.Intn(len(nonceChars))]
-	}
-
-	return string(nonce)
 }

--- a/state_test.go
+++ b/state_test.go
@@ -1,3 +1,5 @@
+// Copyright © 2019 Arrikto Inc.  All Rights Reserved.
+
 package main
 
 import (

--- a/util.go
+++ b/util.go
@@ -1,7 +1,11 @@
+// Copyright (c) 2018 Antti Myyrä
+// Copyright © 2019 Arrikto Inc.  All Rights Reserved.
+
 package main
 
 import (
 	log "github.com/sirupsen/logrus"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"os"
@@ -66,4 +70,14 @@ func clean(s []string) []string {
 		}
 	}
 	return res
+}
+
+func createNonce(length int) string {
+	nonceChars := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+	var nonce = make([]rune, length)
+	for i := range nonce {
+		nonce[i] = nonceChars[rand.Intn(len(nonceChars))]
+	}
+
+	return string(nonce)
 }


### PR DESCRIPTION
This PR:
* Adds the MIT LICENSE file, same as the ajmyyra/ambassador-auth-oidc project
* Amends the MIT LICENSE file to include copyright to ajmyyra/ambassador-auth-oidc
* Adds license headers to all go source files.
* Fixes project name in README.

/assign @vkoukis 
/assign @iliastsi 

Signed-off-by: Yannis Zarkadas <yanniszark@arrikto.com>