### PR TITLE
deps: update boltstore library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.2.2
 	github.com/tevino/abool v0.0.0-20170917061928-9b9efcf221b5
-	github.com/yosssi/boltstore v1.0.0
+	github.com/yosssi/boltstore v1.0.1-0.20150916121936-36632d491655
 	golang.org/x/crypto v0.0.0-20191002192127-34f69633bfdc // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/time v0.0.0-20190921001708-c4c64cad1fd0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/tevino/abool v0.0.0-20170917061928-9b9efcf221b5 h1:hNna6Fi0eP1f2sMBe/
 github.com/tevino/abool v0.0.0-20170917061928-9b9efcf221b5/go.mod h1:f1SCnEOt6sc3fOJfPQDRDzHOtSXuTtnz0ImG9kPRDV0=
 github.com/yosssi/boltstore v1.0.0 h1:oJthEgNJB/v2TgwrNS2J9S+Cf/8dt2fImf7GT1Qz1hM=
 github.com/yosssi/boltstore v1.0.0/go.mod h1:zSl4HJqNcQ6mxETA0wdp73Pu6rgP37VWQh+xer52324=
+github.com/yosssi/boltstore v1.0.1-0.20150916121936-36632d491655 h1:6MtnxkRnXNw3zdUX/y271QqrkSw89vGpqfO76brQ7+4=
+github.com/yosssi/boltstore v1.0.1-0.20150916121936-36632d491655/go.mod h1:zSl4HJqNcQ6mxETA0wdp73Pu6rgP37VWQh+xer52324=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191002192127-34f69633bfdc h1:c0o/qxkaO2LF5t6fQrT4b5hzyggAkLLlCUjqfRxd8Q4=
 golang.org/x/crypto v0.0.0-20191002192127-34f69633bfdc/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=


### PR DESCRIPTION
Go modules automatically pick v1.0.0 of the yosssi/boltstore library, which doesn't contain quite a few commits.

This PR updates the library version to the latest commit in master.

Maybe a fix for: https://github.com/arrikto/oidc-authservice/issues/2

Signed-off-by: Yannis Zarkadas <yanniszark@arrikto.com>