### PR TITLE
Add CA_BUNDLE to auth service server

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Following environment variables are used by the software.
 * **SERVER_PORT** Port to listen for requests. Default is 8080.
 * **SKIP_AUTH_URI** Space separated whitelist of URIs like "/info /health" to bypass authorization. Contains nothing by default.
   **WARNING:** Make sure that the path in SKIP_AUTH_URI matches the path in the VirtualService definition of your Service Mesh. If it doesn't (eg you whitelist /dex and you match /dex/ in the VirtualService) you could leave resources exposed! (in this example, the /dex path is exposed)
+* **CA_BUNDLE** Path to file containing custom CA certificates to use when connecting to an OIDC provider that uses self-signed certificates.
 
 OIDC-AuthService stores sessions and other state in a local file using BoltDB.
 Other stores will be added soon.


### PR DESCRIPTION
Without this patch, when connecting to a self-hosted Dex instance that
is providing a self-signed certificate, the auth service fails to start
with the error message:

```
  OIDC provider setup failed, retrying in 10 seconds: Get https://example-dex:32000/.well-known/openid-configuration: x509: certificate signed by unknown authority
```

This change adds a CA_BUNDLE environment variable which allows the user
to specify a CA bundle that can validate the OIDC server's certificate,
which will enable the auth service to start and to securely reach the
OIDC provider to authenticate a user.

Fixes https://github.com/arrikto/oidc-authservice/issues/9