### PR TITLE
logout: Revoke refresh/access tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Currently it only supports OIDC's [Authorization Code Flow](http://openid.net/sp
 
 ![OIDC AuthService Sequence Diagram](docs/media/oidc_authservice_sequence_diagram.svg)
 
+## Design Docs
+
+For more details on how various aspects of the AuthService are designed, see the design doc for the relevant section:
+* [Logout](docs/logout.md)
+
 ## Options
 
 Following environment variables are used by the software.

--- a/docs/logout.md
+++ b/docs/logout.md
@@ -1,0 +1,13 @@
+# Logout
+
+After the AuthService authenticates users with an IdP, it tracks the user's
+status by:
+* Issuing a session cookie to be stored in the user's browser.
+* Storing the IDToken, access token and refresh token in the AuthService's
+  database.
+
+The `/logout` endpoint provides a logout functionality from the AuthService.
+On logout, the AuthService will:
+1. Delete the user's session from the database.
+2. Revoke the access/refresh tokens at the IdP (if the IdP provides a 
+   `revocation_endpoint` in the discovery document).

--- a/docs/logout.md
+++ b/docs/logout.md
@@ -8,6 +8,8 @@ status by:
 
 The `/logout` endpoint provides a logout functionality from the AuthService.
 On logout, the AuthService will:
-1. Delete the user's session from the database.
-2. Revoke the access/refresh tokens at the IdP (if the IdP provides a 
-   `revocation_endpoint` in the discovery document).
+1. Revoke the access/refresh tokens at the IdP (if the IdP provides a 
+   `revocation_endpoint` in the discovery document). Token revocation is
+   described in [RFC-7009](https://tools.ietf.org/html/rfc7009). The tokens are
+   stored in the user's session in the backend and never reach the browser.
+2. Delete the user's session from the database.

--- a/docs/logout.md
+++ b/docs/logout.md
@@ -8,7 +8,7 @@ status by:
 
 The `/logout` endpoint provides a logout functionality from the AuthService.
 On logout, the AuthService will:
-1. Revoke the access/refresh tokens at the IdP (if the IdP provides a 
+1. Revoke the access/refresh tokens at the IdP (if the IdP provides a
    `revocation_endpoint` in the discovery document). Token revocation is
    described in [RFC-7009](https://tools.ietf.org/html/rfc7009). The tokens are
    stored in the user's session in the backend and never reach the browser.

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,14 @@
+package main
+
+import "fmt"
+
+var _ error = &requestError{}
+
+type requestError struct {
+	StatusCode int
+	Err        error
+}
+
+func (e *requestError) Error() string {
+	return fmt.Sprintf("status: %d, err: %v", e.StatusCode, e.Err)
+}

--- a/errors.go
+++ b/errors.go
@@ -1,6 +1,8 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+)
 
 var _ error = &requestError{}
 

--- a/handlers.go
+++ b/handlers.go
@@ -112,14 +112,14 @@ func (s *server) callback(w http.ResponseWriter, r *http.Request) {
 
 	ctx := setTLSContext(r.Context(), s.caBundle)
 	// Exchange the authorization code with {access, refresh, id}_token
-	oauth2Token, err := s.oauth2Config.Exchange(ctx, authCode)
+	oauth2Tokens, err := s.oauth2Config.Exchange(ctx, authCode)
 	if err != nil {
 		logger.Errorf("Failed to exchange authorization code with token: %v", err)
 		returnStatus(w, http.StatusInternalServerError, "Failed to exchange authorization code with token.")
 		return
 	}
 
-	rawIDToken, ok := oauth2Token.Extra("id_token").(string)
+	rawIDToken, ok := oauth2Tokens.Extra("id_token").(string)
 	if !ok {
 		logger.Error("No id_token field available.")
 		returnStatus(w, http.StatusInternalServerError, "No id_token field in OAuth 2.0 token.")
@@ -137,7 +137,7 @@ func (s *server) callback(w http.ResponseWriter, r *http.Request) {
 
 	// UserInfo endpoint to get claims
 	claims := map[string]interface{}{}
-	userInfo, err := s.provider.UserInfo(ctx, oauth2.StaticTokenSource(oauth2Token))
+	userInfo, err := s.provider.UserInfo(ctx, oauth2.StaticTokenSource(oauth2Tokens))
 	if err != nil {
 		logger.Errorf("Not able to fetch userinfo: %v", err)
 		returnStatus(w, http.StatusInternalServerError, "Not able to fetch userinfo.")
@@ -158,7 +158,7 @@ func (s *server) callback(w http.ResponseWriter, r *http.Request) {
 	session.Values[userSessionUserID] = claims[s.userIDOpts.claim].(string)
 	session.Values[userSessionClaims] = claims
 	session.Values[userSessionIDToken] = rawIDToken
-	session.Values[userSessionOAuth2Tokens] = oauth2Token
+	session.Values[userSessionOAuth2Tokens] = oauth2Tokens
 	if err := session.Save(r, w); err != nil {
 		logger.Errorf("Couldn't create user session: %v", err)
 	}
@@ -193,13 +193,13 @@ func (s *server) logout(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check if the provider has a revocation_endpoint
-	revocationEndpoint, err := revocationEndpoint(s.provider)
+	_revocationEndpoint, err := revocationEndpoint(s.provider)
 	if err != nil {
 		logger.Warnf("Error getting provider's revocation_endpoint: %v", err)
 	} else {
 		ctx := setTLSContext(r.Context(), s.caBundle)
 		token := session.Values[userSessionOAuth2Tokens].(oauth2.Token)
-		err := revokeTokens(ctx, revocationEndpoint, &token, s.oauth2Config.ClientID, s.oauth2Config.ClientSecret)
+		err := revokeTokens(ctx, _revocationEndpoint, &token, s.oauth2Config.ClientID, s.oauth2Config.ClientSecret)
 		if err != nil {
 			logger.Errorf("Error revoking tokens: %v", err)
 			statusCode := http.StatusInternalServerError

--- a/revoke.go
+++ b/revoke.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/coreos/go-oidc"
+	"github.com/pkg/errors"
+	"golang.org/x/oauth2"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// revocationEndpoint parses the OIDC Provider claims from the discovery document
+// and tries to find the revocation_endpoint.
+func revocationEndpoint(p *oidc.Provider) (string, error) {
+	claims := struct {
+		RevocationEndpoint string `json:"revocation_endpoint"`
+	}{}
+	if err := p.Claims(&claims); err != nil {
+		return "", errors.Wrap(err, "Error unmarshalling provider doc into struct")
+	}
+	if claims.RevocationEndpoint == "" {
+		return "", errors.New("Provider doesn't have a revocation_endpoint")
+	}
+	return claims.RevocationEndpoint, nil
+}
+
+// revokeTokens is a helper that takes an oauth2.Token and revokes the access and refresh tokens.
+// If no tokens are found, it succeeds.
+func revokeTokens(ctx context.Context, revocationEndpoint string, token *oauth2.Token, clientID, clientSecret string) error {
+	if token.AccessToken != "" {
+		err := revokeToken(ctx, revocationEndpoint, token.AccessToken, "access_token", clientID, clientSecret)
+		if err != nil {
+			return errors.Wrap(err, "Failed to revoke access token")
+		}
+	}
+	if token.RefreshToken != "" {
+		err := revokeToken(ctx, revocationEndpoint, token.AccessToken, "refresh_token", clientID, clientSecret)
+		if err != nil {
+			return errors.Wrap(err, "Failed to revoke refresh token")
+		}
+	}
+	return nil
+}
+
+// revokeToken takes care of revoking an access/refresh token to the IdP.
+// The revocation procedure is described in RFC7009:+
+// https://tools.ietf.org/html/rfc7009
+func revokeToken(ctx context.Context, revocationEndpoint string, token, tokenType, clientID, clientSecret string) error {
+	// Verify revocation_endpoint has https url
+	if !strings.HasPrefix(revocationEndpoint, "https") {
+		return errors.New(fmt.Sprintf("Revocation endpoint (%v) MUST use https", revocationEndpoint))
+	}
+	values := url.Values{}
+	values.Set("token", token)
+	values.Set("token_type_hint", tokenType)
+	req, err := http.NewRequest(http.MethodPost, revocationEndpoint, strings.NewReader(values.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	// Assume provider accepts http basic auth, because it is REQUIRED by the spec
+	req.SetBasicAuth(clientID, clientSecret)
+
+	resp, err := doRequest(ctx, req)
+	if err != nil {
+		return errors.Wrap(err, "Error contacting revocation endpoint")
+	}
+	if code := resp.StatusCode; code != 200 {
+		// Try to parse JSON response
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return errors.New(fmt.Sprintf("Revocation endpoint returned code %v, failed to read body: %v", code, err))
+		}
+		return errors.New(fmt.Sprintf("Revocation endpoint returned code %v, server returned: %v", code, body))
+	}
+	return nil
+}

--- a/revoke.go
+++ b/revoke.go
@@ -70,7 +70,9 @@ func revokeToken(ctx context.Context, revocationEndpoint string, token, tokenTyp
 		return errors.Wrap(err, "Error contacting revocation endpoint")
 	}
 	if code := resp.StatusCode; code != 200 {
-		// Try to parse JSON response
+		// Read body to include in error for debugging purposes.
+		// According to RFC6749 (https://tools.ietf.org/html/rfc6749#section-5.2)
+		// the body should be in JSON, if we want to parse it in the future.
 		defer resp.Body.Close()
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {

--- a/util.go
+++ b/util.go
@@ -104,3 +104,11 @@ func setTLSContext(ctx context.Context, caBundle []byte) context.Context {
 	tlsConf := &http.Client{Transport: tr}
 	return context.WithValue(ctx, oauth2.HTTPClient, tlsConf)
 }
+
+func doRequest(ctx context.Context, req *http.Request) (*http.Response, error) {
+	client := http.DefaultClient
+	if c, ok := ctx.Value(oauth2.HTTPClient).(*http.Client); ok {
+		client = c
+	}
+	return client.Do(req.WithContext(ctx))
+}

--- a/util.go
+++ b/util.go
@@ -110,5 +110,7 @@ func doRequest(ctx context.Context, req *http.Request) (*http.Response, error) {
 	if c, ok := ctx.Value(oauth2.HTTPClient).(*http.Client); ok {
 		client = c
 	}
+	// TODO: Consider retrying the request if response code is 503
+	// See: https://tools.ietf.org/html/rfc7009#section-2.2.1
 	return client.Do(req.WithContext(ctx))
 }


### PR DESCRIPTION
Currently, logout deletes the user's session from the AuthService database.
However, the access/refresh tokens issued for that user continue to be valid.
If the Provider has a `revocation_endpoint`, we should use it to revoke the access/refresh tokens.

OAuth2 token revocation is described by [RFC7009](https://www.rfc-editor.org/rfc/rfc7009.html).
In short, a POST request is made to a revocation_endpoint.
The client MUST authenticate itself to request a token revocation.

Signed-off-by: Yannis Zarkadas <yanniszark@arrikto.com>