### PR TITLE
server: Change session cookie SameSite policy to Lax

### DIFF
--- a/server.go
+++ b/server.go
@@ -225,7 +225,7 @@ func (s *server) callback(w http.ResponseWriter, r *http.Request) {
 	session.Options.MaxAge = s.sessionMaxAgeSeconds
 	session.Options.Path = "/"
 	// Extra layer of CSRF protection
-	session.Options.SameSite = http.SameSiteStrictMode
+	session.Options.SameSite = http.SameSiteLaxMode
 
 	userID, ok := claims[s.idTokenOpts.userIDClaim].(string)
 	if !ok {


### PR DESCRIPTION
Using a strict SameSite policy is sometimes too restrictive. For
example, an application that is protected by the AuthService may be
acting as an OIDC/OAuth client to a third-party application. In that
case, the SameSite=strict policy prevents the Provider->Client auth code
redirect from working, as it originates from the Provider origin.
Change SameSite policy to Lax, which allows cookies only from cross-site
requests / redirects using the GET method.

Signed-off-by: Yannis Zarkadas <yanniszark@arrikto.com>