### PR TITLE
Add `COOKIE_SAME_SITE` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Session store-related settings:
 | - | - | - |
 | `SESSION_STORE_PATH` | "/var/lib/authservice/data.db" | Path to local session store. Backed by BoltDB. |
 | `SESSION_MAX_AGE` | "86400" | Time in seconds after which sessions expire. Defaults to a day (24h). |
+| `SESSION_SAME_SITE` | "Lax" | SameSite attribute of the session cookie. Check details of SameSite attribute [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite). Its value can be "None", "Lax" or "Strict"  |
 
 By default, the AuthService keeps sessions to check if a user is authenticated. However, there may be times where
 we want to check a user's logged in status at the Provider, effectively making the Provider the one keeping the

--- a/main.go
+++ b/main.go
@@ -176,6 +176,7 @@ func main() {
 		caBundle:                caBundle,
 		authenticators:          []authenticator.Request{sessionAuthenticator, k8sAuthenticator},
 		authorizers:             []Authorizer{groupsAuthorizer},
+		sessionSameSite:         c.SessionSameSite,
 	}
 
 	// Setup complete, mark server ready

--- a/settings.go
+++ b/settings.go
@@ -47,6 +47,7 @@ type config struct {
 	CABundlePath       string `split_words:"true" envconfig:"CA_BUNDLE"`
 	SessionStorePath   string `split_words:"true" default:"/var/lib/authservice/data.db"`
 	SessionMaxAge      int    `split_words:"true" default:"86400"`
+	SessionSameSite    string `split_words:"true" default:"Lax"`
 
 	// Site
 	ClientName          string            `split_words:"true" default:"AuthService"`


### PR DESCRIPTION
Add an option to control the SameSite attribute of the
`Set-Cookie` response header. Default value is `Strict`.