### PR TITLE
minor bugfix + improve authorization ux

### DIFF
--- a/authenticator_session.go
+++ b/authenticator_session.go
@@ -95,10 +95,17 @@ func (sa *sessionAuthenticator) AuthenticateRequest(r *http.Request) (*authentic
 		}
 	}
 
+	// Data written at a previous version might not have groups stored, so
+	// default it.
+	groups, ok := session.Values[userSessionGroups].([]string)
+	if !ok {
+		groups = []string{}
+	}
+
 	resp := &authenticator.Response{
 		User: &user.DefaultInfo{
 			Name:   session.Values[userSessionUserID].(string),
-			Groups: session.Values[userSessionGroups].([]string),
+			Groups: groups,
 		},
 	}
 	return resp, true, nil

--- a/authorizer_groups.go
+++ b/authorizer_groups.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"k8s.io/apiserver/pkg/authentication/user"
 )
@@ -45,6 +46,7 @@ func (ga *groupsAuthorizer) Authorize(r *http.Request, userinfo user.Info) (bool
 			return true, "", nil
 		}
 	}
-	reason := fmt.Sprintf("User's groups ('%v') are not in allowlist.", userinfo.GetGroups())
+	reason := fmt.Sprintf("User's groups ([%s]) are not in allowlist.",
+		strings.Join(userinfo.GetGroups(), ","))
 	return false, reason, nil
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -237,6 +237,9 @@ func (suite *E2ETestSuite) TestDexLogin() {
 	resp, err = httpClient.Do(req)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+	resp, err = httpClient.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusFound, resp.StatusCode)
 }
 
 // login performs an OIDC login and return the session cookie
@@ -290,7 +293,7 @@ func login(t *testing.T, appURL *url.URL, username, password string) string {
 	require.Nil(t, err)
 	require.Equal(t, http.StatusFound, resp.StatusCode)
 
-	// Get Cookie and make authenticated request
+	// Get Cookie
 	cookie := strings.Split(resp.Header.Get("Set-Cookie"), ";")[0]
 	return cookie
 }

--- a/e2e/manifests/authservice/base/kustomization.yaml
+++ b/e2e/manifests/authservice/base/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - envoy-filter.yaml
 - pvc.yaml
 - rbac.yaml
+- virtualservice.yaml
 
 namespace: istio-system
 

--- a/e2e/manifests/authservice/base/params.env
+++ b/e2e/manifests/authservice/base/params.env
@@ -4,3 +4,4 @@ OIDC_AUTH_URL=/dex/auth
 OIDC_SCOPES=profile,email,groups
 SKIP_AUTH_URLS=/dex/
 GROUPS_ALLOWLIST=a,d,e,system:serviceaccounts
+STRICT_SESSION_VALIDATION=true

--- a/e2e/manifests/authservice/base/params.yaml
+++ b/e2e/manifests/authservice/base/params.yaml
@@ -5,3 +5,5 @@ varReference:
   kind: EnvoyFilter
 - path: spec/configPatches/patch/value/config/http_service/server_uri/cluster
   kind: EnvoyFilter
+- path: spec/http/route/destination/host
+  kind: VirtualService

--- a/main.go
+++ b/main.go
@@ -130,6 +130,14 @@ func main() {
 	}
 
 	// Get OIDC Session Authenticator
+	oauth2Config := &oauth2.Config{
+		ClientID:     c.ClientID,
+		ClientSecret: c.ClientSecret,
+		Endpoint:     endpoint,
+		RedirectURL:  c.RedirectURL.String(),
+		Scopes:       c.OIDCScopes,
+	}
+
 	sessionAuthenticator := &sessionAuthenticator{
 		store:                   store,
 		cookie:                  userSessionCookie,
@@ -137,6 +145,7 @@ func main() {
 		strictSessionValidation: c.StrictSessionValidation,
 		caBundle:                caBundle,
 		provider:                provider,
+		oauth2Config:            oauth2Config,
 	}
 
 	groupsAuthorizer := newGroupsAuthorizer(c.GroupsAllowlist)
@@ -145,14 +154,8 @@ func main() {
 	// The isReady atomic variable should protect it from concurrency issues.
 
 	*s = server{
-		provider: provider,
-		oauth2Config: &oauth2.Config{
-			ClientID:     c.ClientID,
-			ClientSecret: c.ClientSecret,
-			Endpoint:     endpoint,
-			RedirectURL:  c.RedirectURL.String(),
-			Scopes:       c.OIDCScopes,
-		},
+		provider:     provider,
+		oauth2Config: oauth2Config,
 		// TODO: Add support for Redis
 		store:                  store,
 		afterLoginRedirectURL:  c.AfterLoginURL.String(),

--- a/session.go
+++ b/session.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/coreos/go-oidc"
+	"github.com/gorilla/sessions"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/oauth2"
+)
+
+const (
+	userSessionCookie       = "authservice_session"
+	userSessionUserID       = "userid"
+	userSessionGroups       = "groups"
+	userSessionClaims       = "claims"
+	userSessionIDToken      = "idtoken"
+	userSessionOAuth2Tokens = "oauth2tokens"
+)
+
+// sessionFromRequestHeader returns a session which has its key in a header.
+// XXX: Because the session library we use doesn't support getting a session
+// by key, we need to fake a cookie
+func sessionFromID(id string, store sessions.Store) (*sessions.Session, error) {
+	r := &http.Request{Header: make(http.Header)}
+	r.AddCookie(&http.Cookie{
+		// XXX: This is needed because the sessions lib we use also encodes
+		// cookies with securecookie, which requires passing the correct cookie
+		// name during decryption.
+		Name:   userSessionCookie,
+		Value:  id,
+		Path:   "/",
+		MaxAge: 1,
+	})
+	return store.Get(r, userSessionCookie)
+}
+
+// sessionFromRequest looks for a session id in a header and a cookie, in that
+// order.
+func sessionFromRequest(r *http.Request, store sessions.Store, cookie,
+	header string) (*sessions.Session, error) {
+
+	// Get session from header or cookie
+	sessionID := getBearerToken(r.Header.Get(header))
+	if sessionID != "" {
+		return sessionFromID(sessionID, store)
+	}
+	return store.Get(r, cookie)
+}
+
+// revokeSession revokes the given session
+// TODO: In the future, we may want to make this function take a function as
+// input, instead of polluting it with extra arguments.
+func revokeSession(ctx context.Context, w http.ResponseWriter,
+	session *sessions.Session, provider *oidc.Provider,
+	oauth2Config *oauth2.Config, caBundle []byte) error {
+
+	logger := logrus.StandardLogger()
+
+	// Revoke the session's OAuth tokens
+	_revocationEndpoint, err := revocationEndpoint(provider)
+	if err != nil {
+		logger.Warnf("Error getting provider's revocation_endpoint: %v", err)
+	} else {
+		token := session.Values[userSessionOAuth2Tokens].(oauth2.Token)
+		err := revokeTokens(setTLSContext(ctx, caBundle), _revocationEndpoint,
+			&token, oauth2Config.ClientID, oauth2Config.ClientSecret)
+		if err != nil {
+			return errors.Wrap(err, "Error revoking tokens")
+		}
+		logger.WithField("userid", session.Values[userSessionUserID].(string)).Info("Access/Refresh tokens revoked")
+	}
+
+	// Delete the session by setting its MaxAge to a negative number.
+	// This will delete the session from the store and also add a "Set-Cookie"
+	// header that will instruct the browser to delete it.
+	// XXX: The session.Save function doesn't really need the request, but only
+	// uses it for its context.
+	session.Options.MaxAge = -1
+	r := &http.Request{}
+	if err := session.Save(r.WithContext(ctx), w); err != nil {
+		return errors.Wrap(err, "Couldn't delete user session")
+	}
+	return nil
+}

--- a/util.go
+++ b/util.go
@@ -35,9 +35,18 @@ func getUserIP(r *http.Request) string {
 	return strings.Split(r.RemoteAddr, ":")[0]
 }
 
-func returnMessage(w http.ResponseWriter, statusCode int, msg string) {
+func returnHTML(w http.ResponseWriter, statusCode int, html string) {
+	w.Header().Set("Content-Type", "text/html")
 	w.WriteHeader(statusCode)
+	_, err := w.Write([]byte(html))
+	if err != nil {
+		log.Errorf("Failed to write body: %v", err)
+	}
+}
+
+func returnMessage(w http.ResponseWriter, statusCode int, msg string) {
 	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(statusCode)
 	_, err := w.Write([]byte(msg))
 	if err != nil {
 		log.Errorf("Failed to write body: %v", err)
@@ -45,18 +54,22 @@ func returnMessage(w http.ResponseWriter, statusCode int, msg string) {
 }
 
 func returnJSONMessage(w http.ResponseWriter, statusCode int, jsonMsg interface{}) {
-	w.WriteHeader(statusCode)
-	w.Header().Set("Content-Type", "application/json")
 	jsonBytes, err := json.Marshal(jsonMsg)
 	if err != nil {
 		log.Errorf("Failed to marshal struct to json: %v", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
 	_, err = w.Write(jsonBytes)
 	if err != nil {
 		log.Errorf("Failed to write body: %v", err)
 	}
+}
+
+func deleteCookie(w http.ResponseWriter, name string) {
+	http.SetCookie(w, &http.Cookie{Name: name, MaxAge: -1, Path: "/"})
 }
 
 func createNonce(length int) string {


### PR DESCRIPTION
This PR contains a bugfix, where we didn't pass the oauth2config all the way to the session-authenticator.
In addition, it improves the UX when the user is not authorized.
When the user is using a browser and is not authorized, they will simply get a 403 page with a message explaining they can't access the upstream. However, there is no way to continue from there (e.g., logout), which makes for a bad UX.

Remedy this by:
- Revoking the user's session if they are unauthorized.
- Returning a message with a link to continue to login.

The branch `feature-plumb-oauth-config-v1` includes an extra commit for an additional check (don't create session if user is not authorized), however, I propose we don't do that.


As for how to test this PR, here is how I tested manually:
- To test the bugfix:
    1. Enable `STRICT_SESSION_VALIDATION` in the ConfigMap and restart the AuthService.
    1. Login with `user`:`12341324`.
    1. Delete Dex's signing key and restart it:
        ```
        kubectl delete signingkeies.dex.coreos.com --all -A
        kubectl delete pods -n auth -l app=dex
        ```
- To test the new authorization mechanism UX (checked by E2E test):
    1. Login with `user`:`12341234` who has a groups that is allowed and see that you are allowed.
    1. Login with `user-nogroups`:`12341234` who doesn't have the correct groups and see that you are not allowed, but immediately logged out and show a message prompting to login. Refreshing the page will return a 302 to login again, because the session was revoked.