### PR TITLE
feature: add an id token authenticator

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ will use it to auto-generate user-visible message in the frontend. , e.g., "You 
 | `HOMEPAGE_URL` | `AUTHSERVICE_URL_PREFIX/site/homepage` | Homepage of the application that can be accessed by anonymous users. |
 | `AFTER_LOGOUT_URL` | `AUTHSERVICE_URL_PREFIX/site/homepage` | URL to redirect the user to after they logout. This option used to be called `STATIC_DESTINATION_URL`. For backwards compatibility, the old environment variable is also checked.|
 | `AUTH_HEADER` | `Authorization` | When the AuthService logs in a user, it creates a session for them and saves it in its database. The session secret value is saved in a cookie in the user's browser. However, for programmatic access to endpoints, it is better to use headers to authenticate. The AuthService also accepts credentials in a header configured by the `AUTH_HEADER` setting. |
+| `ID_TOKEN_HEADER` | `Authorization` | When id token is carried in this header, OIDC Authservice verifies the id token and uses the `USERID_CLAIM` inside the id token. If the `USERID_CLAIM` doesn't exist, the authentication would fail.|
 
 The AuthService provides a web server with some defaults pages for a `homepage`
 and an `after_logout` page. The following values are about these pages. To

--- a/authenticator_idtoken.go
+++ b/authenticator_idtoken.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"net/http"
+
+	oidc "github.com/coreos/go-oidc"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+type idTokenAuthenticator struct {
+	header      string // header name where id token is stored
+	caBundle    []byte
+	provider    *oidc.Provider
+	clientID    string // need client id to verify the id token
+	userIDClaim string // retrieve the userid if the claim exists
+	groupsClaim string
+}
+
+func (s *idTokenAuthenticator) AuthenticateRequest(r *http.Request) (*authenticator.Response, bool, error) {
+	logger := loggerForRequest(r)
+
+	// get id-token from header
+	bearer := getBearerToken(r.Header.Get(s.header))
+	if len(bearer) == 0 {
+		return nil, false, nil
+	}
+
+	ctx := setTLSContext(r.Context(), s.caBundle)
+
+	// Verifying received ID token
+	verifier := s.provider.Verifier(&oidc.Config{ClientID: s.clientID})
+	token, err := verifier.Verify(ctx, bearer)
+	if err != nil {
+		logger.Errorf("id-token verification failed: %v", err)
+		return nil, false, nil
+	}
+
+	var claims map[string]interface{}
+	if err := token.Claims(&claims); err != nil {
+		logger.Errorf("retrieving user claims failed: %v", err)
+		return nil, false, nil
+	}
+
+	if claims[s.userIDClaim] == nil {
+		// No USERID_CLAIM, pass this authenticator
+		logger.Error("USERID_CLAIM doesn't exist in the id token")
+		return nil, false, nil
+	}
+
+	groups := []string{}
+	groupsClaim := claims[s.groupsClaim]
+	if groupsClaim != nil {
+		groups = interfaceSliceToStringSlice(groupsClaim.([]interface{}))
+	}
+
+	resp := &authenticator.Response{
+		User: &user.DefaultInfo{
+			Name:   claims[s.userIDClaim].(string),
+			Groups: groups,
+		},
+	}
+	return resp, true, nil
+}

--- a/main.go
+++ b/main.go
@@ -152,6 +152,15 @@ func main() {
 
 	groupsAuthorizer := newGroupsAuthorizer(c.GroupsAllowlist)
 
+	idTokenAuthenticator := &idTokenAuthenticator{
+		header:      c.IDTokenHeader,
+		caBundle:    caBundle,
+		provider:    provider,
+		clientID:    c.ClientID,
+		userIDClaim: c.UserIDClaim,
+		groupsClaim: c.GroupsClaim,
+	}
+
 	// Set the server values.
 	// The isReady atomic variable should protect it from concurrency issues.
 
@@ -177,8 +186,12 @@ func main() {
 		strictSessionValidation: c.StrictSessionValidation,
 		authHeader:              c.AuthHeader,
 		caBundle:                caBundle,
-		authenticators:          []authenticator.Request{sessionAuthenticator, k8sAuthenticator},
-		authorizers:             []Authorizer{groupsAuthorizer},
+		authenticators: []authenticator.Request{
+			sessionAuthenticator,
+			idTokenAuthenticator,
+			k8sAuthenticator,
+		},
+		authorizers: []Authorizer{groupsAuthorizer},
 	}
 	switch c.SessionSameSite {
 	case "None":

--- a/settings.go
+++ b/settings.go
@@ -39,6 +39,7 @@ type config struct {
 	UserIDClaim       string `split_words:"true" default:"email" envconfig:"USERID_CLAIM"`
 	UserIDTokenHeader string `split_words:"true" envconfig:"USERID_TOKEN_HEADER"`
 	GroupsClaim       string `split_words:"true" default:"groups"`
+	IDTokenHeader     string `split_words:"true" default:"Authorization" envconfig:"ID_TOKEN_HEADER"`
 
 	// Infra
 	Hostname           string `split_words:"true" envconfig:"SERVER_HOSTNAME"`


### PR DESCRIPTION
The id token authenticator verifies the token in the header.
The header name of id token is specified by the `ID_TOKEN_HEADER`
config. The authenticator retrieves the USERID_CLAIM after the
verification. If there is no id token header, the verification failes
or the USERID_CLAIM does not exist, the request is passed to the
next authenticator.