### PR TITLE
refactor: Move SameSite switch statement to init

### DIFF
--- a/main.go
+++ b/main.go
@@ -176,7 +176,15 @@ func main() {
 		caBundle:                caBundle,
 		authenticators:          []authenticator.Request{sessionAuthenticator, k8sAuthenticator},
 		authorizers:             []Authorizer{groupsAuthorizer},
-		sessionSameSite:         c.SessionSameSite,
+	}
+	switch c.SessionSameSite {
+	case "None":
+		s.sessionSameSite = http.SameSiteNoneMode
+	case "Strict":
+		s.sessionSameSite = http.SameSiteStrictMode
+	default:
+		// Use Lax mode as defauls
+		s.sessionSameSite = http.SameSiteLaxMode
 	}
 
 	// Setup complete, mark server ready

--- a/server.go
+++ b/server.go
@@ -44,7 +44,7 @@ type server struct {
 	idTokenOpts             jwtClaimOpts
 	upstreamHTTPHeaderOpts  httpHeaderOpts
 	caBundle                []byte
-	sessionSameSite         string
+	sessionSameSite         http.SameSite
 }
 
 // jwtClaimOpts specifies the location of the user's identity inside a JWT's
@@ -226,15 +226,7 @@ func (s *server) callback(w http.ResponseWriter, r *http.Request) {
 	session.Options.MaxAge = s.sessionMaxAgeSeconds
 	session.Options.Path = "/"
 	// Extra layer of CSRF protection
-	switch s.sessionSameSite {
-	case "None":
-		session.Options.SameSite = http.SameSiteNoneMode
-	case "Strict":
-		session.Options.SameSite = http.SameSiteStrictMode
-	default:
-		// Use Lax mode as default
-		session.Options.SameSite = http.SameSiteLaxMode
-	}
+	session.Options.SameSite = s.sessionSameSite
 
 	userID, ok := claims[s.idTokenOpts.userIDClaim].(string)
 	if !ok {


### PR DESCRIPTION
This way the switch is only executed at once at startup when
intializing the server rather than each time a session is created
in the callback handler.

Signed-off-by: Adam Setters <asetty@arista.com>