### PR TITLE
feat: Add SESSION_DOMAIN env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Session store-related settings:
 | `SESSION_STORE_PATH` | "/var/lib/authservice/data.db" | Path to local session store. Backed by BoltDB. |
 | `SESSION_MAX_AGE` | "86400" | Time in seconds after which sessions expire. Defaults to a day (24h). |
 | `SESSION_SAME_SITE` | "Lax" | SameSite attribute of the session cookie. Check details of SameSite attribute [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite). Its value can be "None", "Lax" or "Strict". |
+| `SESSION_DOMAIN` | "" | Domain attribute of the session cookie. Check details of Domain attribute [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie)  |
 
 By default, the AuthService keeps sessions to check if a user is authenticated. However, there may be times where
 we want to check a user's logged in status at the Provider, effectively making the Provider the one keeping the

--- a/main.go
+++ b/main.go
@@ -172,6 +172,7 @@ func main() {
 		},
 		sessionMaxAgeSeconds:    c.SessionMaxAge,
 		strictSessionValidation: c.StrictSessionValidation,
+		sessionDomain:           c.SessionDomain,
 		authHeader:              c.AuthHeader,
 		caBundle:                caBundle,
 		authenticators:          []authenticator.Request{sessionAuthenticator, k8sAuthenticator},

--- a/server.go
+++ b/server.go
@@ -38,6 +38,7 @@ type server struct {
 	afterLoginRedirectURL   string
 	homepageURL             string
 	afterLogoutRedirectURL  string
+	sessionDomain           string
 	sessionMaxAgeSeconds    int
 	strictSessionValidation bool
 	authHeader              string
@@ -227,6 +228,7 @@ func (s *server) callback(w http.ResponseWriter, r *http.Request) {
 	session.Options.Path = "/"
 	// Extra layer of CSRF protection
 	session.Options.SameSite = s.sessionSameSite
+	session.Options.Domain = s.sessionDomain
 
 	userID, ok := claims[s.idTokenOpts.userIDClaim].(string)
 	if !ok {

--- a/settings.go
+++ b/settings.go
@@ -48,6 +48,7 @@ type config struct {
 	SessionStorePath   string `split_words:"true" default:"/var/lib/authservice/data.db"`
 	SessionMaxAge      int    `split_words:"true" default:"86400"`
 	SessionSameSite    string `split_words:"true" default:"Lax"`
+	SessionDomain      string `split_words:"true"`
 
 	// Site
 	ClientName          string            `split_words:"true" default:"AuthService"`


### PR DESCRIPTION
Allow the user to customize the Domain attribute for user
session / cookie.

By default the value is "" and will default to the URL used by the
oidc provider when making the request to the callback.

Signed-off-by: Adam Setters <asetty@arista.com>