### PR TITLE
Dockerfile: Upgrade to go1.15.3 and alpine3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Builder Image #
 #################
 
-FROM golang:1.14.1 as builder
+FROM golang:1.15.3-alpine3.12 as builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/oidc-authservice
@@ -19,8 +19,8 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o /go
 # Release Image #
 #################
 
-FROM alpine:3.10
-RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
+FROM alpine:3.12
+RUN apk add --no-cache ca-certificates
 
 ENV USER=authservice
 ENV GROUP=authservice


### PR DESCRIPTION
There are known security vulnerabilities in earlier versions of Go.

Also upgrade the base image to Alpine 3.12 and use that as a base to
build the code too (no need in pulling a larger Debian image for the
build, it doesn't buy us anything).

cc @asetty 