### PR TITLE
security: Don't create predictable session IDs.

### DIFF
--- a/util.go
+++ b/util.go
@@ -5,10 +5,10 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
-	"math/rand"
 	"net/http"
 	"net/url"
 	"path"
@@ -72,14 +72,17 @@ func deleteCookie(w http.ResponseWriter, name string) {
 	http.SetCookie(w, &http.Cookie{Name: name, MaxAge: -1, Path: "/"})
 }
 
-func createNonce(length int) string {
-	nonceChars := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
-	var nonce = make([]rune, length)
+func createNonce(length int) (string, error) {
+	const nonceChars = "abcdefghijklmnopqrstuvwxyz:ABCDEFGHIJKLMNOPQRSTUVWXYZ-0123456789"
+	nonce := make([]byte, length)
+	if _, err := rand.Read(nonce); err != nil {
+		return "", err
+	}
 	for i := range nonce {
-		nonce[i] = nonceChars[rand.Intn(len(nonceChars))]
+		nonce[i] = nonceChars[int(nonce[i])%len(nonceChars)]
 	}
 
-	return string(nonce)
+	return string(nonce), nil
 }
 
 func setTLSContext(ctx context.Context, caBundle []byte) context.Context {


### PR DESCRIPTION
The code was creating nonces to use as a session ID using math/rand,
which follows a predictable sequence.  As a result an attacker could
easily predict session IDs, especially if they have the ability to
generate a session ID for themselves, then they can easily guess where
the sequence is at and trivially hijack other sessions.

This is a high severity security vulnerability.

cc @asetty 