### PR TITLE
oidc: Set Path for csrf cookie

### DIFF
--- a/state.go
+++ b/state.go
@@ -42,6 +42,7 @@ func createState(r *http.Request, w http.ResponseWriter,
 	s := newState(r.URL.Path)
 	session := sessions.NewSession(store, oidcStateCookie)
 	session.Options.MaxAge = int(20 * time.Minute)
+	session.Options.Path = "/"
 	session.Values[sessionValueState] = *s
 
 	err := session.Save(r, w)


### PR DESCRIPTION
PR #51 introduce the oidc_state_csrf cookie for protecting against CSRF
attacks in the OIDC flow. However, the cookie's path is not set, meaning
that the browser will only send it for the path where it was set. Thus,
login cannot be completed successfully. This commit sets the cookie's
path to `/`, same as the session cookie.

Signed-off-by: Yannis Zarkadas <yanniszark@arrikto.com>

**Requirements:**
- Make sure your PR conforms to our [contribution guidelines](../CONTRIBUTING.md)
