### PR TITLE
Remove CORS middleware

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	oidc "github.com/coreos/go-oidc"
-	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	log "github.com/sirupsen/logrus"
 	"github.com/tevino/abool"
@@ -56,7 +55,7 @@ func main() {
 	log.Infof("Starting server at %v:%v", c.Hostname, c.Port)
 	stopCh := make(chan struct{})
 	go func(stopCh chan struct{}) {
-		log.Fatal(http.ListenAndServe(fmt.Sprintf("%s:%d", c.Hostname, c.Port), handlers.CORS()(router)))
+		log.Fatal(http.ListenAndServe(fmt.Sprintf("%s:%d", c.Hostname, c.Port), router))
 		close(stopCh)
 	}(stopCh)
 

--- a/web_server.go
+++ b/web_server.go
@@ -1,13 +1,13 @@
 package main
 
 import (
-	"github.com/gorilla/handlers"
-	"github.com/gorilla/mux"
 	"html/template"
 	"io/ioutil"
 	"net/http"
 	"path/filepath"
 	"strings"
+
+	"github.com/gorilla/mux"
 )
 
 const (
@@ -83,7 +83,7 @@ func (s *WebServer) Start(addr string) error {
 			),
 		)
 
-	return http.ListenAndServe(addr, handlers.CORS()(router))
+	return http.ListenAndServe(addr, router)
 }
 
 // siteHandler returns an http.HandlerFunc that serves a given template


### PR DESCRIPTION

**Description of your changes:**

The AuthService used a CORS middleware as a remnant of the original
fork:
https://github.com/ajmyyra/ambassador-auth-oidc/commit/43dd5ae57de2e4bdfc786fc35dd754ffa508e357

The CORS middleware permits requests with certain default methods and
headers. However, since the default answer is 200, what it actually does
is proxy the CORS requests for those methods. We haven't yet decided how
AuthService will work with CORS and this code seems like a security risk
(e.g., what if the default response code changes tomorrow?).

As such, we remove the code until we tackle the issue of
AuthService + CORS.

**Requirements:**
- Make sure your PR conforms to our [contribution guidelines](../CONTRIBUTING.md)
