### PR TITLE
server: Propagate the original URL

### DIFF
--- a/server.go
+++ b/server.go
@@ -257,14 +257,19 @@ func (s *server) callback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	logger.Info("Login validated with ID token, redirecting.")
-
 	// Getting the firstVisitedURL from the OIDC state
 	var destination = state.FirstVisitedURL
 	if s.afterLoginRedirectURL != "" {
-		destination = s.afterLoginRedirectURL
+		// Redirect to a predefined url from config, add the original url as
+		// `next` query parameter.
+		afterLoginRedirectURL := mustParseURL(s.afterLoginRedirectURL)
+		q := afterLoginRedirectURL.Query()
+		q.Set("next", state.FirstVisitedURL)
+		afterLoginRedirectURL.RawQuery = q.Encode()
+		destination = afterLoginRedirectURL.String()
 	}
-
+	logger.WithField("redirectTo", destination).
+		Info("Login validated with ID token, redirecting.")
 	http.Redirect(w, r, destination, http.StatusFound)
 }
 

--- a/util_test.go
+++ b/util_test.go
@@ -34,7 +34,7 @@ func TestCreateNonce_Simple(t *testing.T) {
 // See: https://en.wikipedia.org/wiki/Pearson%27s_chi-squared_test
 func TestCreateNonce_Distribution(t *testing.T) {
 
-	nonce, err := createNonce(10000000)
+	nonce, err := createNonce(100000000)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}


### PR DESCRIPTION
When `AFTER_LOGIN_URL` is set, after the user is authenticated
`authservice` will redirect the user to the predefined url
defined by `AFTER_LOGIN_URL` and the original path is lost.
With this commit we introduce a new query parameter `next` that
is added when redirecting to `AFTER_LOGIN_URL` that has the
value of the original url that the user first visited.

Also we extended the stored state database to include the
original query parameters. Many applications keep their
internal state in query parameters and it's important
to preserve these values during redirection.

Signed-off-by: Ioannis Bouloumpasis <buluba@arrikto.com>

Closes: #66 
