### PR TITLE
oidc: enable the revocation of the refresh and access tokens (PingID)

### DIFF
--- a/revoke.go
+++ b/revoke.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/coreos/go-oidc"
 	"github.com/pkg/errors"
 	"golang.org/x/oauth2"
@@ -31,16 +32,16 @@ func revocationEndpoint(p *oidc.Provider) (string, error) {
 // revokeTokens is a helper that takes an oauth2.Token and revokes the access and refresh tokens.
 // If no tokens are found, it succeeds.
 func revokeTokens(ctx context.Context, revocationEndpoint string, token *oauth2.Token, clientID, clientSecret string) error {
-	if token.AccessToken != "" {
-		err := revokeToken(ctx, revocationEndpoint, token.AccessToken, "access_token", clientID, clientSecret)
-		if err != nil {
-			return errors.Wrap(err, "Failed to revoke access token")
-		}
-	}
 	if token.RefreshToken != "" {
 		err := revokeToken(ctx, revocationEndpoint, token.RefreshToken, "refresh_token", clientID, clientSecret)
 		if err != nil {
 			return errors.Wrap(err, "Failed to revoke refresh token")
+		}
+	}
+	if token.AccessToken != "" {
+		err := revokeToken(ctx, revocationEndpoint, token.AccessToken, "access_token", clientID, clientSecret)
+		if err != nil {
+			log.Warning("Failed to revoke access token")
 		}
 	}
 	return nil

--- a/revoke.go
+++ b/revoke.go
@@ -2,15 +2,16 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/coreos/go-oidc"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 )
 
@@ -33,15 +34,36 @@ func revocationEndpoint(p *oidc.Provider) (string, error) {
 // If no tokens are found, it succeeds.
 func revokeTokens(ctx context.Context, revocationEndpoint string, token *oauth2.Token, clientID, clientSecret string) error {
 	if token.RefreshToken != "" {
+		log.Info("Attempting to revoke refresh token...")
 		err := revokeToken(ctx, revocationEndpoint, token.RefreshToken, "refresh_token", clientID, clientSecret)
 		if err != nil {
 			return errors.Wrap(err, "Failed to revoke refresh token")
 		}
+		log.Info("Successfully revoked refresh token")
 	}
 	if token.AccessToken != "" {
+		log.Info("Attempting to revoke access token...")
 		err := revokeToken(ctx, revocationEndpoint, token.AccessToken, "access_token", clientID, clientSecret)
 		if err != nil {
-			log.Warning("Failed to revoke access token")
+			code := err.(*requestError).Response.StatusCode
+			if code == 400 {
+				bodyMap := make(map[string]string)
+
+				err2 := json.Unmarshal(err.(*requestError).Body, &bodyMap)
+				if err2 != nil {
+					err2 = errors.Wrap(err2, "Error while attempting to unmarshal the body of the request")
+					full_error := errors.New(err.Error() + err2.Error())
+					return errors.Wrap(full_error, "Error while attempting to revoke access token")
+				}
+
+				if bodyMap["error"] == "unsupported_token_type" {
+					log.Warning("The Identity Provider does not support revoking access tokens")
+					return nil
+				}
+			}
+			return errors.Wrap(err, "Failed to revoke access token")
+		} else {
+			log.Info("Successfully revoked access token")
 		}
 	}
 	return nil


### PR DESCRIPTION
**Description:**
We have integrated PingID with Kubeflow, using AuthService and the OIDC 
protocol. During the logout, the revocation of the ``refresh`` and ``access`` 
tokens fails. This is because the current implementation of the 
`oidc-authservice` does not follow the ``RFC7009`` specification.
In this PR we implement the RFC7009 specification which states
the following:
> Implementations MUST support the revocation of refresh tokens 
> and SHOULD support the revocation of access tokens...

Token Revocation: (https://datatracker.ietf.org/doc/html/rfc7009#section-2)

The current ``oidc-authservice`` implementation does **not** tolerate 
any error during the revocation of both the ``refresh`` and the ``access`` 
tokens. To implement the aforementioned specification we modify the 
``revoke.go``:
- Replace the ``error`` return value with a warning message 
  for the case that the revocation of the access token fails
- Add log messages before and after the revocation of each 
  token for the state of the revocation

Signed-off-by: Athanasios Markou athamark@arrikto.com

**Requirements:**
- This PR complies with the requirements described in the
  (../CONTRIBUTING.md)
