### PR TITLE
e2e: Upgrade K3d and K3s versions, fix CI breakage

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -428,9 +428,9 @@ func waitForDeployment(
 func createK3DCluster() error {
 	// FIXME: Prefer creating a cluster with a random name. Else, try to remove
 	// the cluster before creating it.
-	cmd := exec.Command("k3d", "cluster", "create", "e2e-test-cluster", "--k3s-server-arg",
+	cmd := exec.Command("k3d", "cluster", "create", "e2e-test-cluster", "--image", "rancher/k3s:v1.19.15-k3s1", "--k3s-server-arg",
 		"--no-deploy=traefik", "--no-lb", "--wait", "--timeout", "5m",
-		"--update-default-kubeconfig=false")
+		"--kubeconfig-update-default=false")
 	cmd.Stderr, cmd.Stdout = os.Stderr, os.Stdout
 	err := cmd.Run()
 	if err != nil {

--- a/hack/binary_deps.py
+++ b/hack/binary_deps.py
@@ -11,10 +11,10 @@ import urllib.request
 
 log = logging.getLogger(__name__)
 
-KUSTOMIZE_URL = "https://github.com/kubernetes-sigs/kustomize/releases/download/v3.2.0/kustomize_3.2.0_linux_amd64"
+KUSTOMIZE_URL = "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v4.4.0/kustomize_v4.4.0_linux_amd64.tar.gz"
 GO_URL = "https://dl.google.com/go/go1.14.1.linux-amd64.tar.gz"
-KUBECTL_URL = "https://storage.googleapis.com/kubernetes-release/release/v1.18.2/bin/linux/amd64/kubectl"
-K3D_URL = "https://github.com/rancher/k3d/releases/download/v3.0.1/k3d-linux-amd64"
+KUBECTL_URL = "https://storage.googleapis.com/kubernetes-release/release/v1.19.15/bin/linux/amd64/kubectl"
+K3D_URL = "https://github.com/rancher/k3d/releases/download/v4.4.8/k3d-linux-amd64"
 
 
 def parse_args():
@@ -58,7 +58,7 @@ def main():
     download_from_tar(GO_URL, args.output_dir, flatten=False)
 
     log.info("Installing kustomize...")
-    download_to(KUSTOMIZE_URL, os.path.join(args.output_dir, "kustomize"))
+    download_from_tar(KUSTOMIZE_URL, args.output_dir)
     os.chmod(os.path.join(args.output_dir, "kustomize"), stat.S_IRWXU)
 
     log.info("Installing kubectl...")


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
None

**Description of your changes:**

The GitHub Workflows for the repository are currently failing.

Here's the current situation:

1. Kernel versions after 5.12.2 made sysctl variable `nf_conntrack_max` read-only for non-init net namespaces (https://github.com/torvalds/linux/commit/2671fa4dc0109d3fb581bc3078fdf17b5d9080f6). This change was backported to earlier kernel versions as well.

2. K3s minor versions before {1.18.19, 1.19.11, 1.20.7, 1.21.1} by default insist on setting this variable and break otherwise.

3. On their 2021/07/26 update, GH Actions bumped the kernel version of the GH-hosted runners to `5.4.0-1055-azure`. This kernel upgrade broke our GH Workflow because it included change (1).

In order to fix this, we must use a K3s image that contains the fix (https://github.com/k3s-io/k3s/pull/3337).

Given this necessity, we should also seize the opportunity to upgrade K3d to the latest version (4.4.8) and switch from K3s minor 1.18 to 1.19, using the latest (1.19.15) version.

It also makes sense to upgrade the versions of `kustomize`
(to the latest) and `kubectl` (to a version matching K3s).

**Summary of proposed changes**:
* bump K3d to 4.4.8
* bump K3s to 1.19.15
* bump kustomize to 4.4.0
* bump kubectl to 1.19.15
