### PR TITLE
authenticators: Add Auth-Method header

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ Applications can then use those headers to identify the user.
 | `USERID_HEADER` | "kubeflow-userid" | Name of the header containing the user-id that will be added to the upstream request. |
 | `USERID_PREFIX` | "" | Prefix to add to the userid, which will be the value of the `USERID_HEADER`. |
 | `USERID_TRANSFORMERS` | "" | List of transformations for the userid value (from `USERID_CLAIM`) in JSON format `[{"matches": "regex", "replaces": "value"}, ...]`. OIDC AuthService will evaluate the transformation rules in order and if the `matches` pattern matches the userid, the match is replaced by the `replaces` value.  **If multiple rules match, only the first one is applied** and if no rule matches the userid, the original userid will be used. For the `matches` regular expression, use the standard `golang` syntax [(more info)](https://golang.org/pkg/regexp/). Note that a regular expression is a string and the `\` **must be escaped** (using `\\`). For example using `USERID_TRANSFORMERS = '[{"matches": "user@domain\\.com$", "replaces": "internal"}, {"matches": "@domain\\.com$", "replaces": ""}]'`, AuthService will do the following transformation:  `user@domain.com` -> `internal` and `another@domain.com` -> `another`. |
-| `GROUPS_HEADER` | "kubeflow-groups" | Name of the header containing the groups that will be added to the upstream request.
+| `GROUPS_HEADER` | "kubeflow-groups" | Name of the header containing the groups that will be added to the upstream request. |
+| `AUTH_METHOD_HEADER` | "Auth-Method" | Name of the header that is included in the proxied requests to inform the upstream app about the authentication method used (`cookie` / `header`). |
 
 OIDC AuthService can also perform basic authorization checks. The following
 settings are related to authorization:

--- a/authenticator_idtoken.go
+++ b/authenticator_idtoken.go
@@ -55,10 +55,14 @@ func (s *idTokenAuthenticator) AuthenticateRequest(r *http.Request) (*authentica
 		groups = interfaceSliceToStringSlice(groupsClaim.([]interface{}))
 	}
 
+	// Authentication using header successfully completed
+	extra := map[string][]string{"auth-method": {"header"}}
+
 	resp := &authenticator.Response{
 		User: &user.DefaultInfo{
 			Name:   claims[s.userIDClaim].(string),
 			Groups: groups,
+			Extra:  extra,
 		},
 	}
 	return resp, true, nil

--- a/authenticator_session.go
+++ b/authenticator_session.go
@@ -38,7 +38,7 @@ func (sa *sessionAuthenticator) AuthenticateRequest(r *http.Request) (*authentic
 	logger := loggerForRequest(r, "session authenticator")
 
 	// Get session from header or cookie
-	session, err := sessionFromRequest(r, sa.store, sa.cookie, sa.header)
+	session, authMethod, err := sessionFromRequest(r, sa.store, sa.cookie, sa.header)
 
 	// Check if user session is valid
 	if err != nil {
@@ -86,10 +86,13 @@ func (sa *sessionAuthenticator) AuthenticateRequest(r *http.Request) (*authentic
 		groups = []string{}
 	}
 
+	extra := map[string][]string{"auth-method": {authMethod}}
+
 	resp := &authenticator.Response{
 		User: &user.DefaultInfo{
 			Name:   session.Values[userSessionUserID].(string),
 			Groups: groups,
+			Extra:  extra,
 		},
 	}
 	return resp, true, nil

--- a/main.go
+++ b/main.go
@@ -178,9 +178,10 @@ func main() {
 			groupsClaim: c.GroupsClaim,
 		},
 		upstreamHTTPHeaderOpts: httpHeaderOpts{
-			userIDHeader: c.UserIDHeader,
-			userIDPrefix: c.UserIDPrefix,
-			groupsHeader: c.GroupsHeader,
+			userIDHeader:     c.UserIDHeader,
+			userIDPrefix:     c.UserIDPrefix,
+			groupsHeader:     c.GroupsHeader,
+			authMethodHeader: c.AuthMethodHeader,
 		},
 		userIdTransformer:       c.UserIDTransformer,
 		sessionMaxAgeSeconds:    c.SessionMaxAge,

--- a/server.go
+++ b/server.go
@@ -65,12 +65,13 @@ type jwtClaimOpts struct {
 	groupsClaim string
 }
 
-// httpHeaderOpts specifies the location of the user's identity inside HTTP
-// headers.
+// httpHeaderOpts specifies the location of the user's identity and
+// authentication method inside HTTP headers.
 type httpHeaderOpts struct {
-	userIDHeader string
-	userIDPrefix string
-	groupsHeader string
+	userIDHeader     string
+	userIDPrefix     string
+	groupsHeader     string
+	authMethodHeader string
 }
 
 func (s *server) authenticate(w http.ResponseWriter, r *http.Request) {
@@ -121,7 +122,7 @@ func (s *server) authenticate(w http.ResponseWriter, r *http.Request) {
 		// the session authenticator.
 		if !allowed {
 			logger.Infof("Authorizer '%d' denied the request with reason: '%s'", i, reason)
-			session, err := sessionFromRequest(r, s.store, userSessionCookie, s.authHeader)
+			session, _, err := sessionFromRequest(r, s.store, userSessionCookie, s.authHeader)
 			if err != nil {
 				logger.Errorf("Error getting session for request: %v", err)
 			}

--- a/settings.go
+++ b/settings.go
@@ -25,6 +25,7 @@ type config struct {
 	AuthserviceURLPrefix *url.URL `required:"true" split_words:"true"`
 	SkipAuthURLs         []string `split_words:"true" envconfig:"SKIP_AUTH_URLS"`
 	AuthHeader           string   `split_words:"true" default:"Authorization"`
+	AuthMethodHeader     string   `split_words:"true" default:"Auth-Method"`
 	Audiences            []string `default:"istio-ingressgateway.istio-system.svc.cluster.local"`
 	HomepageURL          *url.URL `split_words:"true"`
 	AfterLoginURL        *url.URL `split_words:"true"`

--- a/util.go
+++ b/util.go
@@ -157,6 +157,11 @@ func userInfoToHeaders(info user.Info, opts *httpHeaderOpts, transformer *UserID
 	res := map[string]string{}
 	res[opts.userIDHeader] = opts.userIDPrefix + transformer.Transform(info.GetName())
 	res[opts.groupsHeader] = strings.Join(info.GetGroups(), ",")
+	if authMethodArr, ok := info.GetExtra()["auth-method"]; ok {
+		if len(authMethodArr) > 0 && authMethodArr[0] != "" {
+			res[opts.authMethodHeader] = authMethodArr[0]
+		}
+	}
 	return res
 }
 


### PR DESCRIPTION
Add header to inform upstream app (i.e. Rok, KFP) about the authn method
used. More specifically, on successful authentication, an 'Auth-Method'
header is added to the request, with its value depending on the
authenticator that completed the authentication process and the method
used:
* `authenticator_session`:
   On authn success, sets `Auth-Method` header to:
    - `header` if a session ID token was used
    - `cookie` if a session cookie was used
* `authenticator_idtoken`:
   On authn success, sets `Auth-Method` header to `header`
* `authenticator_kubernetes`:
   On authn success, sets `Auth-Method` header to `header`

Refs arrikto/dev#965

Signed-off-by: Phoevos Kalemkeris <phoevos@arrikto.com>