### PR TITLE
logs: improve log messages

### DIFF
--- a/authenticator_idtoken.go
+++ b/authenticator_idtoken.go
@@ -18,11 +18,12 @@ type idTokenAuthenticator struct {
 }
 
 func (s *idTokenAuthenticator) AuthenticateRequest(r *http.Request) (*authenticator.Response, bool, error) {
-	logger := loggerForRequest(r)
+	logger := loggerForRequest(r, "idtoken authenticator")
 
 	// get id-token from header
 	bearer := getBearerToken(r.Header.Get(s.header))
 	if len(bearer) == 0 {
+		logger.Info("No bearer token found")
 		return nil, false, nil
 	}
 

--- a/authenticator_session.go
+++ b/authenticator_session.go
@@ -35,7 +35,7 @@ type sessionAuthenticator struct {
 }
 
 func (sa *sessionAuthenticator) AuthenticateRequest(r *http.Request) (*authenticator.Response, bool, error) {
-	logger := loggerForRequest(r)
+	logger := loggerForRequest(r, "session authenticator")
 
 	// Get session from header or cookie
 	session, err := sessionFromRequest(r, sa.store, sa.cookie, sa.header)
@@ -45,6 +45,7 @@ func (sa *sessionAuthenticator) AuthenticateRequest(r *http.Request) (*authentic
 		return nil, false, errors.Wrap(err, "couldn't get user session")
 	}
 	if session.IsNew {
+		logger.Info("Failed to retrieve a valid session")
 		return nil, false, nil
 	}
 

--- a/session.go
+++ b/session.go
@@ -48,7 +48,7 @@ func sessionFromID(id string, store sessions.Store) (*sessions.Session, error) {
 func sessionFromRequest(r *http.Request, store sessions.Store, cookie,
 	header string) (*sessions.Session, error) {
 
-	logger := loggerForRequest(r)
+	logger := loggerForRequest(r, "session authenticator")
 	// Try to get session from header
 	sessionID := getBearerToken(r.Header.Get(header))
 	if sessionID != "" {
@@ -57,7 +57,7 @@ func sessionFromRequest(r *http.Request, store sessions.Store, cookie,
 			logger.Infof("Loading session from header %s", header)
 			return s, nil
 		}
-		logger.Debugf("Header %s didn't contain a valid session id: %v", header, err)
+		logger.Infof("Header %s didn't contain a valid session id: %v", header, err)
 	}
 	// Header failed, try to get session from cookie
 	logger.Infof("Loading session from cookie %s", cookie)

--- a/util.go
+++ b/util.go
@@ -32,8 +32,9 @@ func realpath(path string) (string, error) {
 	return path, nil
 }
 
-func loggerForRequest(r *http.Request) *log.Entry {
+func loggerForRequest(r *http.Request, info string) *log.Entry {
 	return log.WithContext(r.Context()).WithFields(log.Fields{
+		"context": info, // include info about the module generating the log
 		"ip":      getUserIP(r),
 		"request": r.URL.String(),
 	})

--- a/web_server.go
+++ b/web_server.go
@@ -1,13 +1,14 @@
 package main
 
 import (
-	"github.com/gorilla/handlers"
-	"github.com/gorilla/mux"
 	"html/template"
 	"io/ioutil"
 	"net/http"
 	"path/filepath"
 	"strings"
+
+	"github.com/gorilla/handlers"
+	"github.com/gorilla/mux"
 )
 
 const (
@@ -89,7 +90,7 @@ func (s *WebServer) Start(addr string) error {
 // siteHandler returns an http.HandlerFunc that serves a given template
 func siteHandler(tmpl *template.Template, data interface{}) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		logger := loggerForRequest(r)
+		logger := loggerForRequest(r, "web server")
 		if err := tmpl.Execute(w, data); err != nil {
 			logger.Errorf("Error executing template: %v", err)
 		}


### PR DESCRIPTION
Improve log messages so that they provide a more accurate/clear picture
of the execution/authentication state:
* Include the `context` string in log entries to show the name of the
  software module generating each message. Possible contexts currently:
  - `server`
  - `web server`
  - `session authenticator`
  - `idtoken authenticator`
  - `kubernetes authenticator`
* Add Authenticator Start messages
* Add Authenticator Success message
* Add messages wherever missing in the authentication process

Refs arrikto/dev#1711

Signed-off-by: Phoevos Kalemkeris <phoevos@arrikto.com>