### PR TITLE
oidc: handle email_verified for bool and string values

### DIFF
--- a/oidc_test.go
+++ b/oidc_test.go
@@ -127,3 +127,63 @@ func TestGetUserInfo_ContextCancelled(t *testing.T) {
 			reqErr.Response.StatusCode, http.StatusUnauthorized)
 	}
 }
+
+func TestParseUserInfo(t *testing.T){
+
+	testCases := []struct{
+		testName 		 string
+		userInfoResponse string
+		success			 bool
+	}{
+		{
+			testName: "EmailVerified: true (boolean)",
+			userInfoResponse: `{"sub": "", "profile": "", "email": "", "email_verified": true}`,
+			success: true,
+		},
+		{
+			testName: "EmailVerified: false (boolean)",
+			userInfoResponse: `{"sub": "","profile": "","email": "","email_verified": false}`,
+			success: true,
+		},
+		{
+			testName: "EmailVerified: true (string)",
+			userInfoResponse: `{"sub": "","profile": "","email": "","email_verified": "true"}`,
+			success: true,
+		},
+		{
+			testName: "EmailVerified: false (string)",
+			userInfoResponse: `{"sub": "","profile": "","email": "","email_verified": "false"}`,
+			success: true,
+		},
+		{
+			testName: "EmailVerified: nil",
+			userInfoResponse: `{"sub": "","profile": "","email": ""}`,
+			success: true,
+		},
+		{
+			testName: "EmailVerified: not boolean, not string, not nil",
+			userInfoResponse: `{"sub": "","profile": "","email": "","email_verified": 42}`,
+			success: false,
+		},
+		{
+			testName: "EmailVerified: irrelevant string",
+			userInfoResponse: `{"sub": "","profile": "","email": "","email_verified": "fals"}`,
+			success: false,
+		},
+	}
+
+	for _, c := range testCases {
+		t.Run(c.testName, func(t *testing.T) {
+			_, err:= ParseUserInfo([]byte(c.userInfoResponse))
+
+			success := true
+			if err != nil {
+				success = false
+			}
+
+			if success != c.success {
+				t.Errorf("ParseUserInfo result for %v is not the expected one.", c)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Support both `bool` and `string` values for the EmailVerified field of the UserInfo struct

Some external Identity Providers deviate from the standard OpenID spec (https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims). One particular divergence from the spec is that their `/userinfo` endpoint responds with a `string` value for the EmailVerified field. The spec specifies that this field should accept `bool` values. We want to extend AuthService to cover this as well.

This is the case for Identity Providers such as:
* Apple: https://developer.apple.com/forums/thread/121411 
* PayPal: https://community.auth0.com/t/userinfo-email-verified-field-string-boolean-or-both/27553
* AWS Cognito: https://forums.aws.amazon.com/thread.jspa?threadID=324806

For these Identity Providers, AuthService fails with:
```
level=error msg="Not able to fetch userinfo: oidc: failed to decode userinfo: json: cannot unmarshal string into Go struct field UserInfo.email_verified of type bool"
```

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/arrikto/oidc-authservice/issues/63

**Description of your changes:**

We extend the `GetUserInfo()` function of the `oidc.go` to handle both `bool` and `string` values for the `email_verified` field of the UserInfo struct. If the `email_verified` field is not configured in the Provider's application side then AuthService will pass `false` as the value of this field as it did prior to our implementation. 

We have tested our implementation for both compliant (PingID) and non-compliant (AWS Cognito) Identity Providers.

