### PR TITLE
Add caching mechanism in AuthService

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,14 @@ Applications can then use those headers to identify the user.
 | `GROUPS_HEADER` | "kubeflow-groups" | Name of the header containing the groups that will be added to the upstream request. |
 | `AUTH_METHOD_HEADER` | "Auth-Method" | Name of the header that is included in the proxied requests to inform the upstream app about the authentication method used (`cookie` / `header`). |
 
+OIDC AuthService can authenticate clients based on the bearer token found in the Authorization header of their request. It caches the bearer token and the respective user information. If the incoming request has a cached bearer token then AuthService authenticates this client and proceeds with the basic authorization checks. The following
+settings are related to the caching mechanism:
+
+| Setting | Default | Description |
+| - | - | - |
+| `CACHE_ENABLED` | `false` | Set `CACHE_ENABLED` to `true` to enable caching. |
+| `CACHE_EXPIRATION_MINUTES` | `5` (minutes) | Set the `CACHE_EXPIRATION_MINUTES` value to define how many minutes it takes for every cache entry to expire. |
+
 OIDC AuthService can also perform basic authorization checks. The following
 settings are related to authorization:
 

--- a/authenticator_kubernetes.go
+++ b/authenticator_kubernetes.go
@@ -57,3 +57,10 @@ func (k8sauth *kubernetesAuthenticator) AuthenticateRequest(r *http.Request) (*a
 
 	return resp, found, err
 }
+
+// The Kubernetes Authenticator implements the Cacheable
+// interface with the getCacheKey().
+func (k8sauth *kubernetesAuthenticator) getCacheKey(r *http.Request) (string) {
+	return getBearerToken(r.Header.Get("Authorization"))
+
+}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/gorilla/mux v1.7.3
 	github.com/gorilla/sessions v1.2.0
 	github.com/kelseyhightower/envconfig v1.4.0
+	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/quasoft/memstore v0.0.0-20180925164028-84a050167438

--- a/go.sum
+++ b/go.sum
@@ -248,6 +248,8 @@ github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/settings.go
+++ b/settings.go
@@ -60,6 +60,10 @@ type config struct {
 	TemplatePath        []string          `split_words:"true"`
 	UserTemplateContext map[string]string `ignored:"true"`
 
+	// bearerUserInfoCache configuration
+	CacheEnabled           bool  `split_words:"true" default:"false" envconfig:"CACHE_ENABLED"`
+	CacheExpirationMinutes int   `split_words:"true" default:"5" envconfig:"CACHE_EXPIRATION_MINUTES"`
+
 	// Authorization
 	GroupsAllowlist []string `split_words:"true" default:"*"`
 }

--- a/util.go
+++ b/util.go
@@ -20,6 +20,10 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 )
 
+type Cacheable interface {
+	getCacheKey(r *http.Request) string
+}
+
 func realpath(path string) (string, error) {
 	path, err := filepath.Abs(path)
 	if err != nil {


### PR DESCRIPTION
## Add Caching Mechanism in AuthService
Introduce a caching mechanism for AuthService. When enabled,
AuthService will store freshly authenticated **Bearer Token** in its 
cache for a configurable amount of time. Contrary to the existing
implementation when a client makes a request with a bearer token
in its Authorization header, then **AuthService will examine if this
bearer token is cached**:
* If it is, then AuthService will retrieve the
  corresponding cached **User Info** and will skip the authenticators.
  In this case we consider that the client was successfully authenticated.
* Otherwise, if the bearer token does not exist in the cache, then 
  AuthService will try the available authenticators one-by-one until one
  of them successfully authenticates the client. Then AuthService will
  retrieve the corresponding **User Info** and will cache the **Bearer Token** 
  as the key and the **User Info** as the value of this cache entry. 

Authenticating over and over again the same bearer token can be
time-consuming. In many cases, AuthService has to make a request 
to the Identity Provider to verify that the examined token is valid. 

With our mechanism AuthService only needs to authenticate this
bearer token once via contacting the Identity Provider. Security-wise
the admin should set both the **expiration** and **cleanup interval** 
times to values not greater that the life-expectancy of the token.

**Description of your changes:** 
To provide the aforementioned functionality we introduce the following
envvars:
| Setting | Default Value| Description |
| ------------- | ------------- | ------------- |
| `CACHE_ENABLED`  | `false`  | Set `CACHE_ENABLED` to `true` to enable caching. |
| `CACHE_EXPIRATION`  | `5` (minutes)  | Set the `CACHE_EXPIRATION` value to define how many minutes it takes for every cache entry to expire. |
| `CACHE_CLEANUP_INTERVAL` | `10` (minutes)  | Set the `CACHE_CLEANUP_INTERVAL` value to define how many minutes it takes for every cache entry to be purged from the cache.  |

We have tested our implementation for Dex as the integrated Identity Provider.
