### PR TITLE
Introduce JWT access token authenticator and disable-authenticator functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,13 @@ settings are related to the caching mechanism:
 | `CACHE_ENABLED` | `false` | Set `CACHE_ENABLED` to `true` to enable caching. |
 | `CACHE_EXPIRATION_MINUTES` | `5` (minutes) | Set the `CACHE_EXPIRATION_MINUTES` value to define how many minutes it takes for every cache entry to expire. |
 
+By default, OIDC AuthService attempts to authenticate client requests with each one of the available authentication methods that it supports. In certain use cases the admins may want to skip the checks performed by one or more  of the authentication methods. OIDC AuthService can be configured to skip a particular authentication method via the following configurations:
+| Setting | Default | Description |
+| - | - | - |
+| `IDTOKEN_AUTHN_ENABLED` | `true` | Set `IDTOKEN_AUTHN_ENABLED` to `false` to disable the ID token authentication method. |
+| `JWT_AUTHN_ENABLED` | `true` | Set `JWT_AUTHN_ENABLED` to `false` to disable the JWT access token authentication method. |
+| `KUBERNETES_AUTHN_ENABLED` | `true` | Set `Kubernetes_AUTHN_ENABLED` to `false` to disable the Kubernetes authentication method. |
+
 OIDC AuthService can also perform basic authorization checks. The following
 settings are related to authorization:
 

--- a/authenticator_jwt.go
+++ b/authenticator_jwt.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+	"encoding/json"
+	"fmt"
+
+	oidc "github.com/coreos/go-oidc"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+const (
+	audienceNotfound = "oidc: expected audience"
+)
+
+type jwtTokenAuthenticator struct {
+	header      string // header name where JWT access token is stored
+	caBundle    []byte
+	provider    *oidc.Provider
+	audiences   []string // need client id to verify the id token
+	issuer		string // need this for the local check
+	userIDClaim string // retrieve the userid if the claim exists
+	groupsClaim string
+}
+
+type jwtLocalChecks struct {
+	Issuer    string   `json:"iss"`
+	Audiences audience `json:"aud"`
+}
+
+func (s *jwtTokenAuthenticator) AuthenticateRequest(r *http.Request) (*authenticator.Response, bool, error) {
+	logger := loggerForRequest(r, "JWT access token authenticator")
+
+	// Get JWT access token from header
+	bearer := getBearerToken(r.Header.Get(s.header))
+	if len(bearer) == 0 {
+		logger.Info("No bearer token found")
+		return nil, false, nil
+	}
+
+	ctx := setTLSContext(r.Context(), s.caBundle)
+
+	// Verifying received JWT token
+	for _, aud := range s.audiences {
+		verifier := s.provider.Verifier(&oidc.Config{ClientID: aud})
+		token, err := verifier.Verify(ctx, bearer)
+
+		if err != nil {
+
+			errorMessage := err.Error()
+			if strings.Contains(errorMessage, audienceNotfound) {
+				continue
+			}
+
+
+			// If a local check fails then AuthService will test
+			// the rest of the available authentication methods.
+			if localErr := s.performLocalChecks(bearer); localErr != nil {
+				logger.Errorf("JWT-token verification is not the appropriate" +
+							" authentication method for the received request.")
+				return nil, false, localErr
+			}
+
+			// Return the error of the go-oidc ID token verifier.
+			logger.Errorf("JWT-token verification failed: %v", err)
+			return nil, false, &authenticatorSpecificError{Err: err}
+		}
+
+		// Retrieve the USERID_CLAIM and the GROUPS_CLAIM
+		var claims map[string]interface{}
+		if claimErr := token.Claims(&claims); claimErr != nil {
+			logger.Errorf("Retrieving user claims failed: %v", claimErr)
+			return nil, false, &authenticatorSpecificError{Err: claimErr}
+		}
+
+		userID, groups, claimErr := s.retrieveUserIDGroupsClaims(claims)
+		if claimErr != nil {
+			return nil, false, &authenticatorSpecificError{Err: claimErr}
+		}
+
+		// Authentication using header successfully completed
+		extra := map[string][]string{"auth-method": {"header"}}
+
+		resp := &authenticator.Response{
+			User: &user.DefaultInfo{
+				Name:   userID,
+				Groups: groups,
+				Extra:  extra,
+			},
+		}
+		return resp, true, nil
+	}
+
+	audienceErr := fmt.Errorf("JWT-token verification failed for all the configured audiences")
+	return nil, false, audienceErr
+
+}
+
+// Perform local checks for the issuer and the audiences 
+func (s *jwtTokenAuthenticator) performLocalChecks(bearer string) (error){
+
+	// Verify that the retrieved Bearer token is a parsable JWT token
+	payload, localErr := parseJWT(bearer)
+	if localErr != nil { // Check next authenticator
+		localErr = fmt.Errorf("Could not parse the inspected Bearer token.")
+		return localErr
+	}
+
+	// Retrieve issuer and the audience claims
+	var tokenLocalChecks jwtLocalChecks
+	if localErr = json.Unmarshal(payload, &tokenLocalChecks); localErr != nil { // Check next authenticator
+		localErr = fmt.Errorf("Could not retrieve the \"issuer\" and the \"audience\" claims" +
+					" from the Bearer Token.")
+		return localErr
+	}
+
+	// Check issuer
+	if tokenLocalChecks.Issuer != s.issuer { // Check next authenticator
+		localErr = fmt.Errorf("The retrieved \"iss\" did not match the expected one.")
+		return localErr
+	}
+
+	// Check audiences
+	if !contains(s.audiences, tokenLocalChecks.Audiences){ // Check next authenticator
+		localErr = fmt.Errorf("The retrieved \"aud\" did not match with any of the" +
+					" expected audiences.")
+		return localErr
+	}
+
+	// Local checks succeeded. 
+	return nil
+
+}
+
+// Retrieve the USERID_CLAIM and the GROUPS_CLAIM from the JWT access token
+func (s *jwtTokenAuthenticator) retrieveUserIDGroupsClaims(claims map[string]interface{}) (string, []string, error){
+		
+		if claims[s.userIDClaim] == nil { 
+			claimErr := fmt.Errorf("USERID_CLAIM not found in the JWT token")
+			return "", []string{}, claimErr
+		}
+
+		groups := []string{}
+		groupsClaim := claims[s.groupsClaim]
+		if groupsClaim == nil {
+			claimErr := fmt.Errorf("GROUPS_CLAIM not found in the JWT token")
+			return "", []string{}, claimErr
+		}
+
+		groups = interfaceSliceToStringSlice(groupsClaim.([]interface{}))
+
+		return claims[s.userIDClaim].(string), groups, nil
+}

--- a/authenticator_jwt_test.go
+++ b/authenticator_jwt_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"testing"
+
+)
+
+func TestPerformLocalChecks(t *testing.T) {
+
+	s := &jwtTokenAuthenticator {
+		audiences: []string{
+					"myaudience1",
+					"myaudience2",
+					"00af7fe8-a019-4859-94af-3d0f4009fed5",
+				   },
+		issuer:	   "https://auth.pingone.eu/e6b1425e-6090-4d29-a961-e760860d932a/as",
+	}
+
+	tests := []struct {
+		testName    string
+		bearerToken string
+		success     bool
+	}{
+		{
+			testName: "Non-parsable JWT",
+			bearerToken: "eyJhbGciOiJSUzI1NiIsImtpZCI6ImRlZmF1bHQifQewJ.ur9WEOCjuX6kJ2COJwz058hu1wlYUhs105x8vc-L8fEYFpOUVqWDuaoV-EU-1eThpHvDmGyIKYd4Jhffg",
+			success: false,
+		},
+		{
+			testName: "Wrong issuer",
+			bearerToken: "eyJhbGciOiJSUzI1NiIsImtpZCI6ImRlZmF1bHQifQ.eyJjbGllbnRfaWQiOiJkMDM4NjI3ZC0yOWYzLTQ4YzItOTBkNi1hN2QzOGU4YTdkNWMiLCJpc3MiOiJodHRwczovL2F1dGgucGluZ29uZS5ldS80MjY3ZGQ1MS1kMGJlLTQ2N2EtOTY4OS0zMmU3YzE0ZGU2YTgvYXMiLCJpYXQiOjE2NDkwNzYwNjksImV4cCI6MTY0OTA3OTY2OSwiYXVkIjpbIm15cmVzb3VyY2UyIl0sInNjb3BlIjoibXlUZXN0U2NvcGUyIn0.Tw8HFKKKnHG1-24cg2YCK92J7wmSIKSJDmUIjQvFidpK4xGNamTeVLro5UN5ZO8Y4WmXQQuLZ1nvB7aWu9M2Cm0R7N4wEZJjEv-u-hHTNzJb0e2PXZBRB3eXRnJ5wbUnWY5ABRiHcHK75KvNvGlhr9nUhID-u-auJ3VH5G-5kLvI4YMl2rMXuH5-KkkfNpTUe0iSZ2d4yvfSI6tp-_NY3l1Pc_1GRgKifgeRFTN0VsoLAghyzQaoqSmfKmv8aMLYFwK8tJHK5VP4BTvs6DPpy6kUYkhZKykaCistHLHn0VcnGNy9ZKFpQwc4FTgEhBHnPiUndmYZFiNonEZpiUj4dQ",
+			success: false,
+		},
+		{
+			testName: "Wrong audience",
+			bearerToken: "eyJhbGciOiJSUzI1NiIsImtpZCI6ImRlZmF1bHQifQ.eyJjbGllbnRfaWQiOiJkZDQxOGNkYS00Y2JjLTQ2NWUtYTM5OS1iODcwMzI0ZWU2NmEiLCJpc3MiOiJodHRwczovL2F1dGgucGluZ29uZS5ldS9lNmIxNDI1ZS02MDkwLTRkMjktYTk2MS1lNzYwODYwZDkzMmEvYXMiLCJpYXQiOjE2NDkwNzY0MTYsImV4cCI6MTY0OTA4MDAxNiwiYXVkIjpbIm15VGVzdFJlc291cmNlMiJdLCJzY29wZSI6Im15VGVzdFNjb3BlMiJ9.BwMsVbucqOZ3zOWbC_o5400aIs7G1wvlDDSbyv-yE6YEKpxd5fvgvcnWm483fEmPciJC0oZ7Uv8SG8kPvmYE4HavqT91jX2D7-d0CQrgJKPuIXKmmu3hdlxShsZ_7GG2hM4YcMN4xdxMC5mUncwKbHXgg7njp93tXVMl_eGxfNwh3m2xD8ay_DGkxURT3YNSzA_Nla9wi4fTC_42Bnq_s37--XFf88Ouegbkr6ZsH2j4OhplGzmPskivT-o20cw_cvi3slL0bdVpVIytIyOpAq-Q7X5OHSmOwA19QfR2Va1ZXDWoN5SBa7DG-N8rZ86pw2Qq_4R7Y52izjtyMXJdIg",
+			success: false,
+		},
+		{
+			testName: "Correct issuer and audience",
+			bearerToken: "eyJhbGciOiJSUzI1NiIsImtpZCI6ImRlZmF1bHQifQ.eyJpc3MiOiJodHRwczovL2F1dGgucGluZ29uZS5ldS9lNmIxNDI1ZS02MDkwLTRkMjktYTk2MS1lNzYwODYwZDkzMmEvYXMiLCJzdWIiOiIxYWRkNjk5MC0xNDRjLTRlYjQtOTllNy1iMTg5YzNkMWNiNTAiLCJhdWQiOiIwMGFmN2ZlOC1hMDE5LTQ4NTktOTRhZi0zZDBmNDAwOWZlZDUiLCJpYXQiOjE2NDkwNzMzMzgsImV4cCI6MTY0OTA3NjkzOCwiYWNyIjoiU2luZ2xlX0ZhY3RvciIsImFtciI6WyJwd2QiXSwiYXV0aF90aW1lIjoxNjQ5MDczMzM3LCJhdF9oYXNoIjoiNk9JazEybXN0aVlvYzNfRlFOMW1EQSIsInNpZCI6Ijg3NjcwYTNiLThlYTAtNDQ3OS1hNmY1LWUyMzUwMDBlMzJjZCIsImdyb3VwcyI6WyJteWdyb3VwIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImF0aGFtYXJrQGFycmlrdG8uY29tIiwiZW52IjoiZTZiMTQyNWUtNjA5MC00ZDI5LWE5NjEtZTc2MDg2MGQ5MzJhIiwib3JnIjoiYTFmY2JkYjQtY2MwYS00Mzg3LWI3MzgtMTI4NTg3ZmYwNzYzIiwicDEucmVnaW9uIjoiRVUifQ.iGWCxEJv_2-FFlZMH35xYvl6qFTGXvrZNHKvUIVGbVIfQdt6fKzhpgIknWmtFs8hK9WW0b9Pt-MnclwQkgljtCwSLLh-s96KOnCKxXbSb7rfAd5Ef8B4Cd7q8rMd8qdxJgIbS3MRdH5UvE-ozU9gQdKpqC2R3zhX0jKsgdpLOIOqhBLaVy8rn2o8kPZL_R2M49HB9LVeYlqrbvY_I3noPedcQPybBLCpTv-oIIfQDENyyePGv_By-_O0CsYeKTLfPTxSIcAYGpywoJ8HcUov0l_7Uq0ej1xdXGYzt3Be3LInR2267JTTebi0OQEMgKZzFIkVxxvNuI9T8KkblrvoTw",
+			success: true,
+		},
+	}
+
+	for _, c := range tests {
+		t.Run(c.testName, func(t *testing.T) {
+			err:= s.performLocalChecks(c.bearerToken)
+
+			success := true
+			if err != nil {
+				success = false
+			}
+
+			if success != c.success {
+				t.Errorf("performLocalChecks result for %v is not the expected one. Error %v", c, err)
+			}
+		})
+	}
+}
+
+func TestRetrieveUserIDGroupsClaims(t *testing.T) {
+
+	s := &jwtTokenAuthenticator {
+		userIDClaim: "preferred_username",
+		groupsClaim: "groups",
+	}
+
+	tests := []struct {
+		testName string
+		claims   map[string]interface{}
+		success  bool
+	}{
+		{
+			testName: "No claims",
+			claims: map[string]interface{}{},
+			success: false,
+		},
+		{
+			testName: "No USERID_CLAIM found",
+			claims: map[string]interface{}{
+				"bacon": "delicious",
+				"eggs": struct {
+				  source string
+				  price  float64
+				}{"chicken", 1.75},
+				"steak": true,
+			  },
+			success: false,
+		},
+		{
+			testName: "No GROUPS_CLAIM found",
+			claims: map[string]interface{}{
+				"preferred_username": "myusername",
+			  },
+			success: false,
+		},
+		{
+			testName: "Both USERID_CLAIM and GROUPS_CLAIM exist",
+			claims: map[string]interface{}{
+				"preferred_username": "myusername",
+				"groups": []interface{}{
+					"mygroup",
+					"Strokes",
+				},
+			  },
+			success: true,
+		},
+	}
+
+	for _, c := range tests {
+		t.Run(c.testName, func(t *testing.T) {
+			_, _, err:= s.retrieveUserIDGroupsClaims(c.claims)
+
+			success := true
+			if err != nil {
+				success = false
+			}
+
+			if success != c.success {
+				t.Errorf("retrieveUserIDGroupsClaims result for %v is not the expected one. Error %v", c, err)
+			}
+		})
+	}
+}

--- a/errors.go
+++ b/errors.go
@@ -37,3 +37,19 @@ func (e *loginExpiredError) Error() string {
 func (e *loginExpiredError) Unwrap() error {
 	return e.Err
 }
+
+// The authenticatorSpecificError type is used to inform the calling code
+// that the appropriate authentication method failed to authenticate the 
+// request. 
+// No other authentication method needs to be tested.
+type authenticatorSpecificError struct {
+	Err error
+}
+
+func (e *authenticatorSpecificError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *authenticatorSpecificError) Unwrap() error {
+	return e.Err
+}

--- a/main.go
+++ b/main.go
@@ -205,6 +205,9 @@ func main() {
 		strictSessionValidation: c.StrictSessionValidation,
 		cacheEnabled:            c.CacheEnabled,
 		cacheExpirationMinutes:  c.CacheExpirationMinutes,
+		IDTokenAuthnEnabled:     c.IDTokenAuthnEnabled,
+		JWTAuthnEnabled:         c.JWTAuthnEnabled,
+		KubernetesAuthnEnabled:  c.KubernetesAuthnEnabled,
 		authHeader:              c.AuthHeader,
 		caBundle:                caBundle,
 		authenticators: []authenticator.Request{

--- a/main.go
+++ b/main.go
@@ -163,6 +163,16 @@ func main() {
 		groupsClaim: c.GroupsClaim,
 	}
 
+	jwtTokenAuthenticator := &jwtTokenAuthenticator{
+		header:      c.IDTokenHeader,
+		caBundle:    caBundle,
+		provider:    provider,
+		audiences:   c.Audiences,
+		issuer:	     c.ProviderURL.String(),
+		userIDClaim: c.UserIDClaim,
+		groupsClaim: c.GroupsClaim,
+	}
+
 	// Set the bearerUserInfoCache cache to store
 	// the (Bearer Token, UserInfo) pairs.
 	bearerUserInfoCache := cache.New(time.Duration(c.CacheExpirationMinutes)*time.Minute, time.Duration(CacheCleanupInterval)*time.Minute)
@@ -200,6 +210,7 @@ func main() {
 		authenticators: []authenticator.Request{
 			sessionAuthenticator,
 			idTokenAuthenticator,
+			jwtTokenAuthenticator,
 			k8sAuthenticator,
 		},
 		authorizers: []Authorizer{groupsAuthorizer},

--- a/settings.go
+++ b/settings.go
@@ -61,8 +61,13 @@ type config struct {
 	UserTemplateContext map[string]string `ignored:"true"`
 
 	// bearerUserInfoCache configuration
-	CacheEnabled           bool  `split_words:"true" default:"false" envconfig:"CACHE_ENABLED"`
-	CacheExpirationMinutes int   `split_words:"true" default:"5" envconfig:"CACHE_EXPIRATION_MINUTES"`
+	CacheEnabled           bool `split_words:"true" default:"false" envconfig:"CACHE_ENABLED"`
+	CacheExpirationMinutes int  `split_words:"true" default:"5" envconfig:"CACHE_EXPIRATION_MINUTES"`
+
+	// Authenticators configurations
+	IDTokenAuthnEnabled    bool `split_words:"true" default:"true" envconfig:"IDTOKEN_AUTHN_ENABLED"`
+	JWTAuthnEnabled        bool `split_words:"true" default:"true" envconfig:"JWT_AUTHN_ENABLED"`
+	KubernetesAuthnEnabled bool `split_words:"true" default:"true" envconfig:"KUBERNETES_AUTHN_ENABLED"`
 
 	// Authorization
 	GroupsAllowlist []string `split_words:"true" default:"*"`


### PR DESCRIPTION
In this PR, we introduce:
1. a new JWT access token authenticator. 
2. a disable functionality for specific authenticators

### 1. JWT access token authenticator
We utilize the `go-oidc` implementation of the ID Token verifier (which we already use for the ID Token authenticator). Additionaly, we perform some local checks to validate whether or not the received request was intended to be validated by the JWT authenticator. If the request was indeed destined for this authenticator then AuthService checks none of the rest of the available authenticators.

The idea is to perform **locally the necessary validation** for the received access tokens based on the signatures of the JWT access tokens.

Our implementation should meet the following **requirements**:
Once AuthService receives a JWT access token it has to . Our new authenticator should be able to meet specific requirements. Here we will give a list of specs:
1. When the JWT Token Authenticator fails, AuthService should perform the following sequence of local checks:
    * Parse the JWT.
    * Check that `iss` / `aud` match the authenticator.
    
    If one of these local checks fails, this means that the inspected token was not destined for our JWT Token Authenticator, AuthService should return `HTTP 301` status and it should check the rest of the available authenticators. However, if these checks were successful this means that AuthService tried the appropriate authenticator and the authentication failed. In this scenario, AuthService will return `HTTP 401` and will not try out any other authenticator. 
2. If the JWT access token is expired, then:
    - the authenticator should return an `HTTP 401` 
    - the authenticator should not check the rest of the available authenticators
3. If the JWT access token has an invalid signature (`sig`), then
    - the authenticator should return an `HTTP 401`
    - the authenticator should not check the rest of the available authenticators
4. If the JWT access token is malformed, then our authenticator should fail to authenticate the request and AuthService should try out the next available authenticator.
5. If a malicious user is trying to make multiple requests to the JWKS endpoint then the AuthService should not allow this user to make frequent requests on the JWKS endpoint. This check is heavily dependent on the value of the `kid`.
6. Ιf AuthService can not retrieve neither the `User ID` nor the `groups` claim from the JWT access token, it should return `HTTP 401` status and not try out the rest of the authenticators.
> AuthService should only accept valid JWT access tokens.

### 2. Disable Authenticators

We now allow the admins to disable the authenticator that they do not need for their use-case. They can disable either-one of the following authenticators:
- "idtoken authenticator": they can set the new `IDTOKEN_AUTHN_ENABLED` envvar to `false`
- "JWT access token authenticator": they can set the new `JWT_AUTHN_ENABLED` envvar to `false`
- "kubernetes authenticator" : they can set the new `KUBERNETES_AUTHN_ENABLED` envvar to `false`

This functionality can benefit the users in scenarios where the identities to be authenticated do not correspond to one of the authenticators. For example, there are installation where no Kubernetes identities are being authenticated. In this case, the Kubernetes authenticator simply adds unnecessary authentication overhead.

### Description of your changes
For the **first part**, we have added some **unit-tests** for the helper functions that our new authenticator is using.
For the **second part**, OIDC AuthService can be configured to skip a particular authentication method via the following configurations:
| Setting | Default | Description |
| - | - | - |
| `IDTOKEN_AUTHN_ENABLED` | `true` | Set `IDTOKEN_AUTHN_ENABLED` to `false` to disable the ID token authentication method. |
| `JWT_AUTHN_ENABLED` | `true` | Set `JWT_AUTHN_ENABLED` to `false` to disable the JWT access token authentication method. |
| `KUBERNETES_AUTHN_ENABLED` | `true` | Set `Kubernetes_AUTHN_ENABLED` to `false` to disable the Kubernetes authentication method. |

**Requirements:**
- We have tested the above with PingID as the integrated Identity Provider
