### PR TITLE
Reorder the authentication methods

### DIFF
--- a/main.go
+++ b/main.go
@@ -211,10 +211,10 @@ func main() {
 		authHeader:              c.AuthHeader,
 		caBundle:                caBundle,
 		authenticators: []authenticator.Request{
+			k8sAuthenticator,
+			jwtTokenAuthenticator,
 			sessionAuthenticator,
 			idTokenAuthenticator,
-			jwtTokenAuthenticator,
-			k8sAuthenticator,
 		},
 		authorizers: []Authorizer{groupsAuthorizer},
 	}

--- a/server.go
+++ b/server.go
@@ -28,10 +28,10 @@ var (
 	OIDCCallbackPath      = "/oidc/callback"
 	SessionLogoutPath     = "/logout"
 	authenticatorsMapping = []string{
-		0: "session authenticator",
-		1: "idtoken authenticator",
-		2: "JWT access token authenticator",
-		3: "kubernetes authenticator",
+		0: "kubernetes authenticator",
+		1: "JWT access token authenticator",
+		2: "session authenticator",
+		3: "idtoken authenticator",
 	}
 )
 


### PR DESCRIPTION
## Reorder the authenticators

After embracing the AuthService Caching Mechanism effort (https://github.com/arrikto/oidc-authservice/pull/87), we suggest reordering the authentication methods that AuthService is using. The only authentication method that benefits from the caching mechanism is the `authenticator_kubernetes.go`. This means that the authentication of a Kubernetes-provided token will have to wait until AuthService tries-and-fails for both the Session authentication method and the ID Token authentication method. Since the caching mechanism can really reduce the authentication overhead and boost the performance, it would make sense for AuthService to try out the Kubernetes authentication method first.

**Description of your changes:**
The current order of the authentication methods that AuthService is following is:

i. Session Authenticator
ii. ID Token Authenticator
iii. JWT Access Token Authenticator
iv. Kubernetes Authenticator

We want to change this to:

i. Kubernetes Authenticator
ii. JWT Access Token Authenticator
iii. Session Authenticator
iv. ID Token Authenticator