### PR TITLE
Opaque Access Token Authentication Method

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,9 @@ By default, OIDC AuthService attempts to authenticate client requests with each 
 | Setting | Default | Description |
 | - | - | - |
 | `IDTOKEN_AUTHN_ENABLED` | `true` | Set `IDTOKEN_AUTHN_ENABLED` to `false` to disable the ID token authentication method. |
-| `JWT_AUTHN_ENABLED` | `true` | Set `JWT_AUTHN_ENABLED` to `false` to disable the JWT access token authentication method. |
 | `KUBERNETES_AUTHN_ENABLED` | `true` | Set `Kubernetes_AUTHN_ENABLED` to `false` to disable the Kubernetes authentication method. |
+| `ACCESS_TOKEN_AUTHN_ENABLED` | `true` | Set `ACCESS_TOKEN_AUTHN_ENABLED` to `false` to disable both the access token authentication methods. |
+| `ACCESS_TOKEN_AUTHN` | "jwt" | Set `ACCESS_TOKEN_AUTHN` to either "jwt" to enable the JWT access token authentication method, or "opaque" to enable the opaque access token authentication method. Note the only one of the two access token authentication methods can be used. |
 
 OIDC AuthService can also perform basic authorization checks. The following
 settings are related to authorization:

--- a/authenticator_opaque.go
+++ b/authenticator_opaque.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"net/http"
+
+	oidc "github.com/coreos/go-oidc"
+	"github.com/pkg/errors"
+	"golang.org/x/oauth2"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+type opaqueTokenAuthenticator struct {
+	header        string // header name where opaque access token is stored
+	caBundle      []byte
+	provider      *oidc.Provider
+	oauth2Config  *oauth2.Config
+	userIDClaim   string // retrieve the userid claim
+	groupsClaim   string // retrieve the groups claim
+}
+
+func (s *opaqueTokenAuthenticator) AuthenticateRequest(r *http.Request) (*authenticator.Response, bool, error) {
+	logger := loggerForRequest(r, "opaque access token authenticator")
+
+	// get id-token from header
+	bearer := getBearerToken(r.Header.Get(s.header))
+	if len(bearer) == 0 {
+		logger.Info("No bearer token found")
+		return nil, false, nil
+	}
+
+	opaque := &oauth2.Token {
+		AccessToken: bearer,
+		TokenType: "Bearer",
+	}
+
+	ctx := setTLSContext(r.Context(), s.caBundle)
+
+	userInfo, err := GetUserInfo(ctx, s.provider, s.oauth2Config.TokenSource(ctx, opaque))
+	if err != nil {
+		var reqErr *requestError
+		if !errors.As(err, &reqErr) {
+			return nil, false, errors.Wrap(err, "UserInfo request failed unexpectedly")
+		}
+
+		return nil, false, errors.Wrapf(err, "UserInfo request failed with code '%d'", reqErr.Response.StatusCode)
+	}
+
+	// Retrieve the USERID_CLAIM and the GROUPS_CLAIM
+	var claims map[string]interface{}
+	if claimErr := userInfo.Claims(&claims); claimErr != nil {
+		logger.Errorf("Retrieving user claims failed: %v", claimErr)
+		return nil, false, &authenticatorSpecificError{Err: claimErr}
+	}
+
+	userID, groups, claimErr := s.retrieveUserIDGroupsClaims(claims)
+	if claimErr != nil {
+		return nil, false, &authenticatorSpecificError{Err: claimErr}
+	}
+
+	// Authentication using header successfully completed
+	extra := map[string][]string{"auth-method": {"header"}}
+
+	resp := &authenticator.Response{
+		User: &user.DefaultInfo{
+			Name:   userID,
+			Groups: groups,
+			Extra:  extra,
+		},
+	}
+	return resp, true, nil
+}
+
+// Retrieve the USERID_CLAIM and the GROUPS_CLAIM from the /userinfo response
+func (s *opaqueTokenAuthenticator) retrieveUserIDGroupsClaims(claims map[string]interface{}) (string, []string, error){
+
+	if claims[s.userIDClaim] == nil {
+		claimErr := errors.New("USERID_CLAIM not found in the response of the userinfo endpoint")
+		return "", []string{}, claimErr
+	}
+
+	groups := []string{}
+	groupsClaim := claims[s.groupsClaim]
+	if groupsClaim == nil {
+		claimErr := errors.New("GROUPS_CLAIM not found in the response of the userinfo endpoint")
+		return "", []string{}, claimErr
+	}
+
+	groups = interfaceSliceToStringSlice(groupsClaim.([]interface{}))
+
+	return claims[s.userIDClaim].(string), groups, nil
+}
+
+// The Opaque Access Token Authenticator implements the Cacheable
+// interface with the getCacheKey().
+func (s *opaqueTokenAuthenticator) getCacheKey(r *http.Request) (string) {
+	return getBearerToken(r.Header.Get("Authorization"))
+
+}

--- a/authenticator_opaque_test.go
+++ b/authenticator_opaque_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestValidAccessTokenAuthn(t *testing.T) {
+
+	tests := []struct {
+		testName string
+		AccessTokenAuthnEnabled bool
+		AccessTokenAuthn string
+		success  bool
+	}{
+		{
+			testName: "Access Token Authenticator is set to JWT",
+			AccessTokenAuthnEnabled: true,
+			AccessTokenAuthn: "jwt",
+			success: true,
+		},
+		{
+			testName: "Access Token Authenticator is set to opaque",
+			AccessTokenAuthnEnabled: true,
+			AccessTokenAuthn: "opaque",
+			success: true,
+		},
+		{
+			testName: "Access Token Authenticator is disabled",
+			AccessTokenAuthnEnabled: false,
+			AccessTokenAuthn: "whatever",
+			success: true,
+		},
+		{
+			testName: "Access Token Authenticator envvar is invalid (JWT)",
+			AccessTokenAuthnEnabled: true,
+			AccessTokenAuthn: "JWT",
+			success: false,
+		},
+		{
+			testName: "Access Token Authenticator envvar is invalid (Opaque)",
+			AccessTokenAuthnEnabled: true,
+			AccessTokenAuthn: "Opaque",
+			success: false,
+		},
+	}
+
+	for _, c := range tests {
+		t.Run(c.testName, func(t *testing.T) {
+			result := validAccessTokenAuthn(c.AccessTokenAuthnEnabled, c.AccessTokenAuthn)
+
+			if result != c.success {
+				t.Errorf("validAccessTokenAuthn result for %v is not the expected one.", c)
+			}
+		})
+	}
+}
+
+func TestRetrieveUserIDGroupsUserInfo(t *testing.T) {
+
+	s := &opaqueTokenAuthenticator {
+		userIDClaim: "preferred_username",
+		groupsClaim: "groups",
+	}
+
+	tests := []struct {
+		testName string
+		claims   map[string]interface{}
+		success  bool
+	}{
+		{
+			testName: "No claims",
+			claims: map[string]interface{}{},
+			success: false,
+		},
+		{
+			testName: "No USERID_CLAIM found",
+			claims: map[string]interface{}{
+				"bacon": "delicious",
+				"eggs": struct {
+				  source string
+				  price  float64
+				}{"chicken", 1.75},
+				"steak": true,
+			  },
+			success: false,
+		},
+		{
+			testName: "No GROUPS_CLAIM found",
+			claims: map[string]interface{}{
+				"preferred_username": "myusername",
+			  },
+			success: false,
+		},
+		{
+			testName: "Both USERID_CLAIM and GROUPS_CLAIM exist",
+			claims: map[string]interface{}{
+				"preferred_username": "myusername",
+				"groups": []interface{}{
+					"mygroup",
+					"Strokes",
+				},
+			  },
+			success: true,
+		},
+	}
+
+	for _, c := range tests {
+		t.Run(c.testName, func(t *testing.T) {
+			_, _, err:= s.retrieveUserIDGroupsClaims(c.claims)
+
+			success := true
+			if err != nil {
+				success = false
+			}
+
+			if success != c.success {
+				t.Errorf("retrieveUserIDGroupsClaims result for %v is not the expected one. Error %v", c, err)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/arrikto/oidc-authservice
 
-go 1.12
+go 1.15
 
 require (
 	github.com/boltdb/bolt v1.3.1
@@ -11,17 +11,18 @@ require (
 	github.com/gorilla/mux v1.7.3
 	github.com/gorilla/sessions v1.2.0
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
-	github.com/quasoft/memstore v0.0.0-20180925164028-84a050167438
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0
 	github.com/tevino/abool v0.0.0-20170917061928-9b9efcf221b5
 	github.com/yosssi/boltstore v1.0.1-0.20150916121936-36632d491655
 	golang.org/x/exp v0.0.0-20201008143054-e3b2a7f2fdc7 // indirect
+	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
-	golang.org/x/tools v0.0.0-20201022035929-9cf592e881e9 // indirect
+	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gonum.org/v1/gonum v0.8.1
 	gopkg.in/square/go-jose.v2 v2.3.1 // indirect
 	k8s.io/api v0.18.2

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,7 @@ github.com/evanphx/json-patch v4.5.0+incompatible h1:ouOWdg56aJriqS0huScTkVXPC5I
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
+github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -86,6 +87,7 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logr/logr v0.1.0 h1:M1Tv3VzNlEHg6uyACnRdtrploV2P7wZqH8BoQMtz0cg=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
+github.com/go-logr/zapr v0.1.0 h1:h+WVe9j6HAA01niTJPA/kKH0i7e0rLZBCwauQFcRE54=
 github.com/go-logr/zapr v0.1.0/go.mod h1:tabnROwaDl0UNxkVeFRbY8bwB37GwRv0P8lg6aAiEnk=
 github.com/go-openapi/analysis v0.0.0-20180825180245-b006789cd277/go.mod h1:k70tL6pCuVxPJOHXQ+wIac1FUrvNkHolPie/cLEU6hI=
 github.com/go-openapi/analysis v0.17.0/go.mod h1:IowGgpVeD0vNm45So8nr+IcQ3pxVtpRoBWb8PVZO0ik=
@@ -137,11 +139,10 @@ github.com/go-openapi/validate v0.19.5/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85n
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
-github.com/gogo/protobuf v1.3.0 h1:G8O7TerXerS4F6sx9OV7/nRfJdnXgHZu/S/7F2SN+UE=
-github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef h1:veQD95Isof8w9/WXiA+pa3tz3fJXkt5B7QaRBrM62gk=
@@ -191,6 +192,7 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
@@ -212,9 +214,11 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -244,9 +248,11 @@ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.11.0 h1:JAKSXpt1YjtLA7YpPiqO9ss6sNXEsPfSGdwN0UHqzrw=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/onsi/gomega v1.8.1 h1:C5Dqfs/LeauYDX0jJXIe2SWmwCbGzx9yF8C8xy3Lh34=
 github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
@@ -276,8 +282,6 @@ github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2 h1:6LJUbpNm42llc4HRCuvApCSWB/WfhuNo9K98Q9sNGfs=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
-github.com/quasoft/memstore v0.0.0-20180925164028-84a050167438 h1:jnz/4VenymvySjE+Ez511s0pqVzkUOmr1fwCVytNNWk=
-github.com/quasoft/memstore v0.0.0-20180925164028-84a050167438/go.mod h1:wTPjTepVu7uJBYgZ0SdWHQlIas582j6cn2jgk4DDdlg=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
@@ -286,6 +290,7 @@ github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
+github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
@@ -316,7 +321,6 @@ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yosssi/boltstore v1.0.1-0.20150916121936-36632d491655 h1:6MtnxkRnXNw3zdUX/y271QqrkSw89vGpqfO76brQ7+4=
 github.com/yosssi/boltstore v1.0.1-0.20150916121936-36632d491655/go.mod h1:zSl4HJqNcQ6mxETA0wdp73Pu6rgP37VWQh+xer52324=
-github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
 go.mongodb.org/mongo-driver v1.0.3/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
@@ -324,8 +328,11 @@ go.mongodb.org/mongo-driver v1.1.1/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qL
 go.mongodb.org/mongo-driver v1.1.2/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
+go.uber.org/atomic v1.4.0 h1:cxzIVoETapQEqDhQu3QfnvXAV4AlzcvUCxkVUFw3+EU=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
+go.uber.org/multierr v1.1.0 h1:HoEmRHQPVSqub6w2z2d2EOVs2fjyFRGyofhKuyDq0QI=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
+go.uber.org/zap v1.10.0 h1:ORx85nbTijNz8ljznvCMR1ZBIPKFn3jQrag10X2AsuM=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -334,8 +341,6 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190320223903-b7391e95e576/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190617133340-57b3e21c3d56/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20191002192127-34f69633bfdc h1:c0o/qxkaO2LF5t6fQrT4b5hzyggAkLLlCUjqfRxd8Q4=
-golang.org/x/crypto v0.0.0-20191002192127-34f69633bfdc/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975 h1:/Tl7pH94bvbAAHBdZJT947M/+gp0+CqQXDtMRC0fseo=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -358,7 +363,6 @@ golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTk
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
-golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -379,8 +383,6 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2 h1:eDrdRpKgkcCqKZQwyZRyeFZgfqt37SL7Kv3tok06cKE=
-golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974 h1:IX6qOQeG5uLjB/hjjwjedwfjND0hgjPMMyO1RoIXQNI=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -415,8 +417,6 @@ golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
-golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -449,16 +449,16 @@ golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72 h1:bw9doJza/SFBEweII/rHQh3
 golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200207183749-b753a1ba74fa/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
-golang.org/x/tools v0.0.0-20201022035929-9cf592e881e9 h1:sEvmEcJVKBNUvgCUClbUQeHOAa9U0I2Ce1BooMvVCY4=
-golang.org/x/tools v0.0.0-20201022035929-9cf592e881e9/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.0.1 h1:xyiBuvkD2g5n7cYzx6u2sxQvsAy4QJsZFCzGVdzOXZ0=
 gomodules.xyz/jsonpatch/v2 v2.0.1/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
 gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
 gonum.org/v1/gonum v0.8.1 h1:wGtP3yGpc5mCLOLeTeBdjeui9oZSz5De0eOjMLC/QuQ=
 gonum.org/v1/gonum v0.8.1/go.mod h1:oe/vMfY3deqTw+1EZJhuvEW2iwGF1bW9wwu7XCu0+v0=
+gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0 h1:OE9mWmgKkjJyEmDAAtGMPjXu+YNeGvK9VTSHY6+Qihc=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
 gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b/go.mod h1:Wt8AAjI+ypCyYX3nZBvf6cAIx93T+c/OS2HFAYskSZc=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
@@ -480,6 +480,7 @@ google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
@@ -491,6 +492,7 @@ gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.3.1 h1:SK5KegNXmKmqE342YYN2qPHEnUYeoMiXXl1poUlI+o4=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/main.go
+++ b/main.go
@@ -173,6 +173,15 @@ func main() {
 		groupsClaim: c.GroupsClaim,
 	}
 
+	opaqueTokenAuthenticator := &opaqueTokenAuthenticator{
+		header:       c.IDTokenHeader,
+		caBundle:     caBundle,
+		provider:     provider,
+		oauth2Config: oauth2Config,
+		userIDClaim:  c.UserIDClaim,
+		groupsClaim:  c.GroupsClaim,
+	}
+
 	// Set the bearerUserInfoCache cache to store
 	// the (Bearer Token, UserInfo) pairs.
 	bearerUserInfoCache := cache.New(time.Duration(c.CacheExpirationMinutes)*time.Minute, time.Duration(CacheCleanupInterval)*time.Minute)
@@ -212,6 +221,7 @@ func main() {
 		caBundle:                caBundle,
 		authenticators: []authenticator.Request{
 			k8sAuthenticator,
+			opaqueTokenAuthenticator,
 			jwtTokenAuthenticator,
 			sessionAuthenticator,
 			idTokenAuthenticator,

--- a/main.go
+++ b/main.go
@@ -215,8 +215,9 @@ func main() {
 		cacheEnabled:            c.CacheEnabled,
 		cacheExpirationMinutes:  c.CacheExpirationMinutes,
 		IDTokenAuthnEnabled:     c.IDTokenAuthnEnabled,
-		JWTAuthnEnabled:         c.JWTAuthnEnabled,
 		KubernetesAuthnEnabled:  c.KubernetesAuthnEnabled,
+		AccessTokenAuthnEnabled: c.AccessTokenAuthnEnabled,
+		AccessTokenAuthn:        c.AccessTokenAuthn,
 		authHeader:              c.AuthHeader,
 		caBundle:                caBundle,
 		authenticators: []authenticator.Request{

--- a/oidc.go
+++ b/oidc.go
@@ -98,6 +98,7 @@ func GetUserInfo(ctx context.Context, provider *oidc.Provider, tokenSource oauth
 	}
 
 	token, err := tokenSource.Token()
+
 	if err != nil {
 		return nil, errors.Errorf("oidc: get access token: %v", err)
 	}
@@ -113,6 +114,7 @@ func GetUserInfo(ctx context.Context, provider *oidc.Provider, tokenSource oauth
 		return nil, err
 	}
 	if resp.StatusCode != http.StatusOK {
+
 		return nil, &requestError{
 			Response: resp,
 			Body:     body,
@@ -121,6 +123,7 @@ func GetUserInfo(ctx context.Context, provider *oidc.Provider, tokenSource oauth
 	}
 
 	userInfo, err := ParseUserInfo(body)
+
 	if err != nil {
 		return nil, errors.Errorf("oidc: failed to parse userInfo body: %v", err)
 	}

--- a/server.go
+++ b/server.go
@@ -62,9 +62,10 @@ type server struct {
 	cacheExpirationMinutes  int
 
 	// Authenticators Configurations
-	IDTokenAuthnEnabled    bool
-	JWTAuthnEnabled        bool
-	KubernetesAuthnEnabled bool
+	IDTokenAuthnEnabled     bool
+	KubernetesAuthnEnabled  bool
+	AccessTokenAuthnEnabled bool
+	AccessTokenAuthn        string
 
 	authHeader              string
 	idTokenOpts             jwtClaimOpts
@@ -364,16 +365,21 @@ func (s *server) callback(w http.ResponseWriter, r *http.Request) {
 
 // enabledAuthenticator indicates if the examined authenticator is enabled.
 func (s *server) enabledAuthenticator(authenticator string) (bool){
+	if authenticator == "kubernetes authenticator" && s.KubernetesAuthnEnabled {
+		return true
+	}
+	if s.AccessTokenAuthnEnabled {
+		if authenticator == "opaque access token authenticator" && s.AccessTokenAuthn == "opaque" {
+			return true
+		}
+		if authenticator == "JWT access token authenticator" && s.AccessTokenAuthn == "jwt" {
+			return true
+		}
+	}
 	if authenticator == "session authenticator" {
 		return true
 	}
 	if authenticator == "idtoken authenticator" && s.IDTokenAuthnEnabled {
-		return true
-	}
-	if authenticator == "JWT access token authenticator" && s.JWTAuthnEnabled {
-		return true
-	}
-	if authenticator == "kubernetes authenticator" && s.KubernetesAuthnEnabled {
 		return true
 	}
 	return false

--- a/server.go
+++ b/server.go
@@ -29,9 +29,10 @@ var (
 	SessionLogoutPath     = "/logout"
 	authenticatorsMapping = []string{
 		0: "kubernetes authenticator",
-		1: "JWT access token authenticator",
-		2: "session authenticator",
-		3: "idtoken authenticator",
+		1: "opaque access token authenticator",
+		2: "JWT access token authenticator",
+		3: "session authenticator",
+		4: "idtoken authenticator",
 	}
 )
 
@@ -140,7 +141,7 @@ func (s *server) authenticate(w http.ResponseWriter, r *http.Request) {
 			}
 
 			// If AuthService encountered an authenticator-specific error,
-// then no other authentication methods will be tested.
+			// then no other authentication methods will be tested.
 			var authnError *authenticatorSpecificError
 			if errors.As(err, &authnError) {
 				returnMessage(w, http.StatusUnauthorized, authnError.Error())


### PR DESCRIPTION
## Opaque Access Token Authentication Method

We should extend AuthService to support the authentication of opaque access tokens. This method is also known as **remote access token validation method**. 

### How will this authentication method work?

The overall idea is:
1. **AuthService** receives a request with an opaque access token in the Authorization header of the request.
2. **AuthService** retrieves the opaque access token from the header of the incoming request.
3. **AuthService** makes a GET request to the `/userinfo` endpoint of the integrated external Identity Provider with this opaque token in the Authorization header of the outcoming request.
4. If the token is valid and has not expired, then the **Identity Provider** should respond with a list of claims for this user. For example:
    ```
    {
    "family_name" : "Markou",
    "nickname" : "zep",
    "preferred_username" : "athamark@arrikto.com",
    "updated_at" : 1652273291,
    "email" : "athanasiosmarkou96@gmail.com",
    "given_name" : "Athanasios",
    "middle_name" : "Theodore",
    "sub" : "d544f8bb-edc5-4c4d-b622-55a95q6db19",
    "groups" : [ "myGroup1" ],
    "env" : "f23p5q1a-06b8-401p-ml12-3ktr145ffdb73",
    "org" : "4oc6odda-1zi6-3w62-bf6e-306hju8fd8",
    "p1.region" : "EU"
    }
    ```
  
    > If the token has expired then AuthService should return `HTTP 401` status.

5. **AuthService** should retrieve the values for both the `USERID_CLAIM` and the `GROUPS_CLAIM`, in the above example the `USERID_CLAIM` corresponds to `preferred_username` and the `GROUPS_CLAIM` to`groups.

    > If either of these claims does not exist then AuthService should proceed with trying out the rest of the available authentication methods.

### What does this procedure proves?

Making a distinct HTTP GET to the `/userinfo` endpoint (https://developer.okta.com/docs/reference/api/oidc/#userinfo) will succeed only if the token is valid and not expired.
Thus it is safe to conclude that requesting the `/userinfo` endpoint with the opaque access token will both:
* verify that the token is **valid** and not **expired**
* return the user info needed to retrieve the `USERID_CLAIM` and the `GROUPS_CLAIM` values of the client.

### Configurations

We will remove the existing `JWT_AUTHN_ENABLED` and we will introduce a new `ACCESS_TOKEN_AUTHN` env var of type string. This configuration will default to the JWT string. The acceptable values will be:
- `"JWT"`: if set to this value then the JWT access token authenticator will be enabled, the opaque access token authenticator will be disabled
- `"opaque"`:  if set to this value then the JWT access token authenticator will be disabled, the opaque access token authenticator will be enabled
- `"none"`: if set to this value, then both of the aforementioned authenticator will be disabled
To capture the case where the admins have set an unsupported configuration (e.g., Opaque) we will introduce a log error message which will be printed early on when the authservice pod starts, and it will state:
```
Unsupported access token authentication configuration. Please select exactly one of the supported options:
- "JWT": to enable the JWT access token authentication method
- "opaque": to enable the opaque access token authentication method
- "none": to disable the authentication of access tokens
```

If the `ACCESS_TOKEN_AUTHN` is set to another value (e.g. `"Opaquee"`), AuthService will print a fatal message and will not proceed. This way the admins will be obliged to set exactly one of the above options for the access token authentication.

### Requirements
Our implementation must meet the following requirements:
1. Giving an invalid value for the `ACCESS_TOKEN_AUTHN` env var should not allow AuthService to proceed with its execution
2. The opaque authenticator should successfully authenticate non-expired access token that the integrated Identity Provider issued
3. The opaque authenticator should not accept expired access tokens issued by the integrated Identity Provider
4. The opaque authenticator should benefit from the caching mechanism
5. The opaque authenticator must not accept invalid tokens (issued by another non-integrated application or IdP)

We have tested the above with PingID as the external Identity Provider.
