### PR TITLE
authorizers: Add new external authorizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ settings are related to authorization:
 | Setting | Default | Description |
 | - | - | - |
 | `GROUPS_ALLOWLIST` | "*" | List of groups that are allowed to pass authorization. By default, all groups are allowed. If you change this option, you may want to include the `system:serviceaccounts` group explicitly, if you need the AuthService to accept ServiceAccountTokens. |
+| `EXTERNAL_AUTHZ_URL` | "" | Use an external authorization service. This option is disabled by default, to enable set the value to the target external authorization service (e.g. `EXTERNAL_AUTHZ_URL=http://authorizer/auth`). If you have enabled this option then for a request to be authorized, **both** the group and the external authorization service will have to allow the request. |
 
 ## Usage
 

--- a/authorizer_external.go
+++ b/authorizer_external.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ExternalAuthorizer is responsible for handling authorization in an external
+// authorization server.
+type ExternalAuthorizer struct {
+	url string
+}
+
+// AuthorizationRequestBody is the object with the current request metadata that
+// the ExternalAuthorizer will send to external authorizer.
+type AuthorizationRequestBody struct {
+	Timestamp string                   `json:"timestamp"`
+	User      AuthorizationUserInfo    `json:"user"`
+	Request   AuthorizationRequestInfo `json:"request"`
+}
+
+// AuthorizationUserInfo is the sub-object with the user metadata that the
+// ExternalAuthorizer will send to the external authorizer.
+type AuthorizationUserInfo struct {
+	Name   string                 `json:"name"`
+	Id     string                 `json:"id"`
+	Groups []string               `json:"groups"`
+	Extra  map[string][]string    `json:"extra"`
+	Claims map[string]interface{} `json:"claims"`
+}
+
+// AuthorizationRequestInfo is the sub-object with the request metadata that the
+// ExternalAuthorizer will send to the external authorizer.
+type AuthorizationRequestInfo struct {
+	Host   string `json:"host"`
+	Port   int    `json:"port"`
+	Path   string `json:"path"`
+	Method string `json:"method"`
+}
+
+func (e ExternalAuthorizer) Authorize(r *http.Request, userinfo user.Info) (allowed bool, reason string, err error) {
+	// Collect data and create the AuthorizationRequestBody.
+	logger := loggerForRequest(r, "external authorizer")
+	logger = logger.WithField("user", userinfo)
+	authorizationUserInfo := e.getUserInfo(r, userinfo)
+
+	request := e.getRequestInfo(r)
+	timestamp := time.Now().Format(time.RFC3339)
+	body := AuthorizationRequestBody{
+		Timestamp: timestamp,
+		User:      authorizationUserInfo,
+		Request:   request,
+	}
+	// Send the request to the external authorizer.
+	code, responseBody, err := e.doRequest(body)
+	if err != nil {
+		return false, "Error while authorizing the request", err
+	}
+	// If the response of the external authorizer is in the [200, 300) range
+	// allow the request.
+	if code >= 200 && code < 300 {
+		logger.Infof("Request is allowed")
+		return true, "", nil
+	} else if code == 401 || code == 403 {
+		logger.Infof("Request is not allowed")
+		return false, fmt.Sprintf("%v", responseBody), nil
+	}
+
+	err = errors.New(fmt.Sprintf("Authorization server returned unexpected status code: %d with body: %v",
+		code, responseBody))
+	return false, "", err
+}
+
+// getUserInfo creates a AuthorizationUserInfo object for the current context.
+func (e ExternalAuthorizer) getUserInfo(r *http.Request, userinfo user.Info) AuthorizationUserInfo {
+	// Parse the JWT token and add get the claims if it exists.
+	bearer := getBearerToken(r.Header.Get("Authorization"))
+	var parsedJwt map[string]interface{} = nil
+	if bearer != "" {
+		jwt, err := parseJWT(bearer)
+		if err == nil {
+			// Unmarshal the JSON to the interface.
+			err = json.Unmarshal(jwt, &parsedJwt)
+			// Ignore any errors
+		}
+	}
+	return AuthorizationUserInfo{
+		Name:   userinfo.GetName(),
+		Id:     userinfo.GetUID(),
+		Groups: userinfo.GetGroups(),
+		Extra:  userinfo.GetExtra(),
+		Claims: parsedJwt,
+	}
+}
+
+// getRequestInfo creates a AuthorizationRequestInfo object for the current 
+// context.
+func (e ExternalAuthorizer) getRequestInfo(r *http.Request) (request AuthorizationRequestInfo) {
+	host := strings.Split(r.Host, ":")[0]
+	port, _ := strconv.Atoi(strings.Split(r.Host, ":")[1])
+	return AuthorizationRequestInfo{
+		Host:   host,
+		Port:   port,
+		Path:   r.URL.Path,
+		Method: r.Method,
+	}
+}
+
+// doRequest does the request to the external authorization server.
+func (e ExternalAuthorizer) doRequest(requestBody AuthorizationRequestBody) (code int, responseBody string, err error) {
+	// Serialize the object.
+	b, err := json.Marshal(&requestBody)
+	if err != nil {
+		return 0, "", err
+	}
+	// Send the request
+	resp, err := http.Post(e.url, "application/json", bytes.NewBuffer(b))
+	if err != nil {
+		err = fmt.Errorf("error sending the request: %w", err)
+		return 0, "", err
+	}
+	defer resp.Body.Close()
+	response, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		err = fmt.Errorf("error while reading the body: %w", err)
+		return 0, "", err
+	}
+	return resp.StatusCode, string(response), nil
+}

--- a/authorizer_external_test.go
+++ b/authorizer_external_test.go
@@ -1,0 +1,288 @@
+package main
+
+import (
+	"fmt"
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+const (
+	mockAuthUrl = "https://test/auth"
+	// Issuer: "Issuer", Username: "Test", "Role: Test"
+	JWT = "eyJhbGciOiJIUzI1NiJ9.eyJSb2xlIjoiVGVzdCIsIklzc3VlciI6Iklzc3VlciIsIlVzZXJuYW1lIjoiVGVzdCIsImV4cCI6MTY2NzM4MzY0MiwiaWF0IjoxNjY3MzgzNjQyfQ.D75w4zDiQfTwDtrFCz0m9qlBalLhoEhxWqw83unoFCk\n"
+	/* The decoded JWT token has the following content:
+	   Header:
+	   {
+             "alg": "HS256"
+           }
+	   Payload:
+	   {
+             "Role": "Test",
+             "Issuer": "Issuer",
+             "Username": "Test",
+             "exp": 1667383642,
+             "iat": 1667383642
+           }
+	*/
+)
+
+
+func createRequest(addJWT bool) *http.Request {
+	var currentUrl url.URL
+	currentUrl.Path = "/test"
+	var headers = http.Header{}
+	if addJWT {
+		headers.Add("Authorization", fmt.Sprintf("Bearer: %s", JWT))
+	}
+	return &http.Request{
+		Method: "GET",
+		URL:    &currentUrl,
+		Host:   "host:80",
+		Header: headers,
+	}
+}
+
+func TestExternalAuthorizer_Authorize(t *testing.T) {
+
+	type args struct {
+		r        *http.Request
+		userinfo user.Info
+	}
+	type httpMock struct {
+		url    string
+		method string
+		status int
+		body   string
+	}
+	type checks func(t *testing.T)
+	tests := []struct {
+		name          string
+		args          args
+		httpMock      httpMock
+		checks        checks
+		expectAllowed bool
+		expectReason  string
+		expectErr     bool
+	}{
+		{
+			name: "user is allowed",
+			args: args{
+				r:        createRequest(true),
+				userinfo: &user.DefaultInfo{Name: "Test"},
+			},
+			httpMock: httpMock{
+				url: mockAuthUrl,
+				method: "POST",
+				status: 200,
+				body:   "User Allowed",
+			},
+			checks: func(t *testing.T) {
+				// Verify that a call has been made in the backend.
+				calls := httpmock.GetCallCountInfo()[fmt.Sprintf("POST %v",mockAuthUrl)]
+				require.Equal(t, 1, calls)
+			},
+			expectAllowed: true,
+			expectReason:  "",
+			expectErr:     false,
+		},
+		{
+			name: "user is unauthorized",
+			args: args{
+				r:        createRequest(true),
+				userinfo: &user.DefaultInfo{Name: "Test"},
+			},
+			httpMock: httpMock{
+				url: mockAuthUrl,
+				method: "POST",
+				status: 401,
+				body:   "User Unauthorized",
+			},
+			checks: func(t *testing.T) {
+				// Verify that a call has been made in the backend.
+				calls := httpmock.GetCallCountInfo()[fmt.Sprintf("POST %v",mockAuthUrl)]
+				require.Equal(t, 1, calls)
+			},
+			expectAllowed: false,
+			expectReason:  "User Unauthorized",
+			expectErr:     false,
+		},
+		{
+			name: "authorization server exception",
+			args: args{
+				r:        createRequest(true),
+				userinfo: &user.DefaultInfo{Name: "Test"},
+			},
+			httpMock: httpMock{
+				url: mockAuthUrl,
+				method: "POST",
+				status: 500,
+				body:   "Internal server error",
+			},
+			checks: func(t *testing.T) {
+				// Verify that a call has been made in the backend.
+				calls := httpmock.GetCallCountInfo()[fmt.Sprintf("POST %v",mockAuthUrl)]
+				require.Equal(t, 1, calls)
+			},
+			expectAllowed: false,
+			expectReason:  "",
+			expectErr:     true,
+		},
+		{
+			name: "connection error",
+			args: args{
+				r:        createRequest(true),
+				userinfo: &user.DefaultInfo{Name: "Test"},
+			},
+			httpMock: httpMock{
+				url: "http://wrongurl/auth",
+				method: "POST",
+				status: 500,
+				body:   "Internal server error",
+			},
+			checks: func(t *testing.T) {
+				// Verify that a call has not been made in the backend.
+				calls := httpmock.GetCallCountInfo()[fmt.Sprintf("POST %v",mockAuthUrl)]
+				require.Equal(t, 0, calls)
+			},
+			expectAllowed: false,
+			expectReason:  "Error while authorizing the request",
+			expectErr:     true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			e := ExternalAuthorizer{
+				url: mockAuthUrl,
+			}
+			// Mock HTTP.
+			httpmock.Activate()
+			defer httpmock.DeactivateAndReset()
+			httpmock.RegisterResponder(test.httpMock.method, test.httpMock.url,
+				httpmock.NewStringResponder(test.httpMock.status, test.httpMock.body))
+			// Call the method.
+			gotAllowed, gotReason, err := e.Authorize(test.args.r, test.args.userinfo)
+			// Verify
+			if test.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, test.expectAllowed, gotAllowed, "Authorize() gotAllowed = %v, expect %v", gotAllowed, test.expectAllowed)
+			require.Equal(t, test.expectReason, gotReason, "Authorize() gotReason = %v, expect %v", gotReason, test.expectReason)
+
+			if test.checks != nil {
+				test.checks(t)
+			}
+		})
+	}
+}
+
+func TestExternalAuthorizer_getRequestInfo(t *testing.T) {
+	e := ExternalAuthorizer{
+		url: mockAuthUrl,
+	}
+
+	request := createRequest(true)
+
+	r := e.getRequestInfo(request)
+	require.Equal(t, AuthorizationRequestInfo{"host", 80, "/test", "GET"}, r)
+}
+
+func TestExternalAuthorizer_getUserInfo(t *testing.T) {
+	type fields struct {
+		url string
+	}
+	type args struct {
+		r        *http.Request
+		userinfo user.Info
+	}
+	nonJWTAuthorization := createRequest(false)
+	nonJWTAuthorization.Header.Add("Authorization", "Bearer: Test")
+	tests := []struct {
+		name     string
+		fields   fields
+		args     args
+		expectInfo AuthorizationUserInfo
+	}{
+		{
+			name:   "parse user info without JWT",
+			fields: fields{mockAuthUrl},
+			args: args{
+				r: createRequest(false),
+				userinfo: &user.DefaultInfo{
+					Name:   "Test",
+					UID:    "1",
+					Groups: []string{"test"},
+					Extra:  map[string][]string{"test": {"test"}},
+				},
+			},
+			expectInfo: AuthorizationUserInfo{
+				Name:   "Test",
+				Id:     "1",
+				Groups: []string{"test"},
+				Extra:  map[string][]string{"test": {"test"}},
+				Claims: nil,
+			},
+		},
+		{
+			name:   "parse user info with JWT",
+			fields: fields{mockAuthUrl},
+			args: args{
+				r: createRequest(true),
+				userinfo: &user.DefaultInfo{
+					Name:   "Test",
+					UID:    "1",
+					Groups: []string{"test"},
+					Extra:  map[string][]string{"test": {"test"}},
+				},
+			},
+			expectInfo: AuthorizationUserInfo{
+				Name:   "Test",
+				Id:     "1",
+				Groups: []string{"test"},
+				Extra:  map[string][]string{"test": {"test"}},
+				Claims: map[string]interface{}{
+					"Issuer":   "Issuer",
+					"Role":     "Test",
+					"Username": "Test",
+					"exp":      1.667383642e+09,
+					"iat":      1.667383642e+09,
+				},
+			},
+		},
+		{
+			name:   "parse user info with non JWT bearer token",
+			fields: fields{mockAuthUrl},
+			args: args{
+				r: nonJWTAuthorization,
+				userinfo: &user.DefaultInfo{
+					Name:   "Test",
+					UID:    "1",
+					Groups: []string{"test"},
+					Extra:  map[string][]string{"test": {"test"}},
+				},
+			},
+			expectInfo: AuthorizationUserInfo{
+				Name:   "Test",
+				Id:     "1",
+				Groups: []string{"test"},
+				Extra:  map[string][]string{"test": {"test"}},
+				Claims: nil,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			e := ExternalAuthorizer{
+				url: test.fields.url,
+			}
+			gotInfo := e.getUserInfo(test.args.r, test.args.userinfo)
+			require.Equal(t, gotInfo, test.expectInfo, "getUserInfo() gotInfo = %v, expect %v",
+				gotInfo, test.expectInfo)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.7.3
 	github.com/gorilla/sessions v1.2.0
+	github.com/jarcoal/httpmock v1.2.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -198,6 +198,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/jarcoal/httpmock v1.2.0 h1:gSvTxxFR/MEMfsGrvRbdfpRUMBStovlSRLw0Ep1bwwc=
+github.com/jarcoal/httpmock v1.2.0/go.mod h1:oCoTsnAz4+UoOUIf5lJOWV2QQIW5UoeUI6aM2YnWAZk=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -233,6 +235,7 @@ github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/maxatome/go-testdeep v1.11.0/go.mod h1:011SgQ6efzZYAen6fDn4BqQ+lUR72ysdyKe7Dyogw70=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/server.go
+++ b/server.go
@@ -173,10 +173,10 @@ func (s *server) authenticate(w http.ResponseWriter, r *http.Request) {
 	logger = logger.WithField("user", userInfo)
 	logger.Info("Authorizing request...")
 
-	for i, authz := range s.authorizers {
+	for _, authz := range s.authorizers {
 		allowed, reason, err := authz.Authorize(r, userInfo)
 		if err != nil {
-			logger.Errorf("Error authorizing request using authorizer %d: %v", i, err)
+			logger.Errorf("Error authorizing request using authorizer %T: %v", authz, err)
 			w.WriteHeader(http.StatusForbidden)
 			return
 		}
@@ -184,7 +184,7 @@ func (s *server) authenticate(w http.ResponseWriter, r *http.Request) {
 		// TODO: Only revoke if the authenticator that provided the identity is
 		// the session authenticator.
 		if !allowed {
-			logger.Infof("Authorizer '%d' denied the request with reason: '%s'", i, reason)
+			logger.Infof("Authorizer '%T' denied the request with reason: '%s'", authz, reason)
 			session, _, err := sessionFromRequest(r, s.store, userSessionCookie, s.authHeader)
 			if err != nil {
 				logger.Errorf("Error getting session for request: %v", err)

--- a/settings.go
+++ b/settings.go
@@ -72,7 +72,8 @@ type config struct {
 	AccessTokenAuthn        string `split_words:"true" default:"jwt" envconfig:"ACCESS_TOKEN_AUTHN"`
 
 	// Authorization
-	GroupsAllowlist []string `split_words:"true" default:"*"`
+	GroupsAllowlist  []string `split_words:"true" default:"*"`
+	ExternalAuthzUrl string   `split_words:"true" default:""`
 }
 
 func parseConfig() (*config, error) {


### PR DESCRIPTION
Introduce a new authorizer that relies on an external service to authorize the requests.

Authservice will send a POST request to the external authorizer with body in the following format:
{
  "timestamp": "timestamp of the request",
  "user": {
    "name": "username",
    "id": "user id",
    "groups": ["a list of groups"],
    "extra": {// object with extra info},
    "claims": {// object with the JWT claims, if JWT was used}
  },
  "request": {
    "host": "the request host",
    "method": "the request HTTP method",
    "path": "the request patch",
    "port": "the request port"
  }
}

The external service should respond with code [200, 300) if the request is authorized or 401|403 not.

The external authorizer is enabled by setting the 'EXTERNAL_AUTH_URL' to the target authorization service (e.g.
'EXTERNAL_AUTH_URL=http://authorizer/auth').

Signed-off-by: Ioannis Bouloumpasis <buluba@arrikto.com>

