### PR TITLE
server: register oauth callback handler according to REDIRECT_URL

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ func main() {
 
 	// Register handlers for routes
 	router := mux.NewRouter()
-	router.HandleFunc(path.Join(c.AuthserviceURLPrefix.Path, OIDCCallbackPath), s.callback).Methods(http.MethodGet)
+	router.HandleFunc(c.RedirectURL.Path, s.callback).Methods(http.MethodGet)
 	router.HandleFunc(path.Join(c.AuthserviceURLPrefix.Path, SessionLogoutPath), s.logout).Methods(http.MethodPost)
 
 	router.PathPrefix("/").Handler(whitelistMiddleware(c.SkipAuthURLs, isReady)(http.HandlerFunc(s.authenticate)))


### PR DESCRIPTION
Signed-off-by: Junlin Zhou <jameszhou2108@hotmail.com>

**Which issue is resolved by this Pull Request:**
Resolves #86

Register callback function to `config.RedirectURL` so that it works with the `REDIRECT_URL` environment variable. Otherwise the `REDIRECT_URL` env will break the authentication flow.
