### PR TITLE
external-authorizer: Fix when request HOST doesn't have port

### DIFF
--- a/authorizer_external.go
+++ b/authorizer_external.go
@@ -104,10 +104,15 @@ func (e ExternalAuthorizer) getUserInfo(r *http.Request, userinfo user.Info) Aut
 // getRequestInfo creates a AuthorizationRequestInfo object for the current 
 // context.
 func (e ExternalAuthorizer) getRequestInfo(r *http.Request) (request AuthorizationRequestInfo) {
-	host := strings.Split(r.Host, ":")[0]
-	port, _ := strconv.Atoi(strings.Split(r.Host, ":")[1])
+	host := strings.Split(r.Host, ":")
+	// Use 80 as a fallback.
+	var port = 80
+	if len(host) > 1 {
+		port, _ = strconv.Atoi(host[1])
+	}
+	hostname := host[0]
 	return AuthorizationRequestInfo{
-		Host:   host,
+		Host:   hostname,
 		Port:   port,
 		Path:   r.URL.Path,
 		Method: r.Method,


### PR DESCRIPTION
Fix a bug that triggered panic when a request's HOST header did not have the port number.

Signed-off-by: Ioannis Bouloumpasis <buluba@arrikto.com>
