### PR TITLE
Set log level from a new `LOG_LEVEL` env var.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Following environment variables are used by the software.
 | `VERIFY_AUTH_URL` | `AUTHSERVICE_URL_PREFIX/verify` | Path to the `/verify` endpoint. This endpoint examines a subrequest and returns `204` if the user is authenticated and authorized to perform such a request, otherwise it will return `401` if the user cannot be authenticated or `403` if the user is authenticated but they are not authorized to perform this request. |
 | `AUTH_HEADER` | `Authorization` | When the AuthService logs in a user, it creates a session for them and saves it in its database. The session secret value is saved in a cookie in the user's browser. However, for programmatic access to endpoints, it is better to use headers to authenticate. The AuthService also accepts credentials in a header configured by the `AUTH_HEADER` setting. |
 | `ID_TOKEN_HEADER` | `Authorization` | When id token is carried in this header, OIDC Authservice verifies the id token and uses the `USERID_CLAIM` inside the id token. If the `USERID_CLAIM` doesn't exist, the authentication would fail.|
+| `LOG_LEVEL` | "INFO" | Set the log level to one of "FATAL", "ERROR", "WARN", "INFO", or "DEBUG" to specify the verbosity of the OIDC-Authservice logs. |
 
 The AuthService provides a web server with some defaults pages for a `homepage`
 and an `after_logout` page. The following values are about these pages. To

--- a/authenticators/idtoken.go
+++ b/authenticators/idtoken.go
@@ -19,7 +19,7 @@ type IDTokenAuthenticator struct {
 }
 
 func (s *IDTokenAuthenticator) AuthenticateRequest(r *http.Request) (*authenticator.Response, bool, error) {
-	logger := common.LoggerForRequest(r, "idtoken authenticator")
+	logger := common.RequestLogger(r, "idtoken authenticator")
 
 	// get id-token from header
 	bearer := common.GetBearerToken(r.Header.Get(s.Header))

--- a/authenticators/idtoken.go
+++ b/authenticators/idtoken.go
@@ -24,7 +24,7 @@ func (s *IDTokenAuthenticator) AuthenticateRequest(r *http.Request) (*authentica
 	// get id-token from header
 	bearer := common.GetBearerToken(r.Header.Get(s.Header))
 	if len(bearer) == 0 {
-		logger.Info("No bearer token found")
+		logger.Debug("No bearer token found")
 		return nil, false, nil
 	}
 

--- a/authenticators/jwt.go
+++ b/authenticators/jwt.go
@@ -32,7 +32,7 @@ type jwtLocalChecks struct {
 }
 
 func (s *JWTTokenAuthenticator) AuthenticateRequest(r *http.Request) (*authenticator.Response, bool, error) {
-	logger := common.LoggerForRequest(r, "JWT access token authenticator")
+	logger := common.RequestLogger(r, "JWT access token authenticator")
 
 	// Get JWT access token from header
 	bearer := common.GetBearerToken(r.Header.Get(s.Header))

--- a/authenticators/jwt.go
+++ b/authenticators/jwt.go
@@ -37,7 +37,7 @@ func (s *JWTTokenAuthenticator) AuthenticateRequest(r *http.Request) (*authentic
 	// Get JWT access token from header
 	bearer := common.GetBearerToken(r.Header.Get(s.Header))
 	if len(bearer) == 0 {
-		logger.Info("No bearer token found")
+		logger.Debug("No bearer token found")
 		return nil, false, nil
 	}
 

--- a/authenticators/opaque.go
+++ b/authenticators/opaque.go
@@ -26,7 +26,7 @@ func (s *OpaqueTokenAuthenticator) AuthenticateRequest(r *http.Request) (*authen
 	// get id-token from header
 	bearer := common.GetBearerToken(r.Header.Get(s.Header))
 	if len(bearer) == 0 {
-		logger.Info("No bearer token found")
+		logger.Debug("No bearer token found")
 		return nil, false, nil
 	}
 

--- a/authenticators/opaque.go
+++ b/authenticators/opaque.go
@@ -21,7 +21,7 @@ type OpaqueTokenAuthenticator struct {
 }
 
 func (s *OpaqueTokenAuthenticator) AuthenticateRequest(r *http.Request) (*authenticator.Response, bool, error) {
-	logger := common.LoggerForRequest(r, "opaque access token authenticator")
+	logger := common.RequestLogger(r, "opaque access token authenticator")
 
 	// get id-token from header
 	bearer := common.GetBearerToken(r.Header.Get(s.Header))

--- a/authenticators/session.go
+++ b/authenticators/session.go
@@ -36,7 +36,7 @@ type SessionAuthenticator struct {
 }
 
 func (sa *SessionAuthenticator) AuthenticateRequest(r *http.Request) (*authenticator.Response, bool, error) {
-	logger := common.LoggerForRequest(r, "session authenticator")
+	logger := common.RequestLogger(r, "session authenticator")
 
 	// Get session from header or cookie
 	session, authMethod, err := sessions.SessionFromRequest(r, sa.Store, sa.Cookie, sa.Header)

--- a/authorizer_external.go
+++ b/authorizer_external.go
@@ -50,7 +50,7 @@ type AuthorizationRequestInfo struct {
 
 func (e ExternalAuthorizer) Authorize(r *http.Request, userinfo user.Info) (allowed bool, reason string, err error) {
 	// Collect data and create the AuthorizationRequestBody.
-	logger := common.LoggerForRequest(r, "external authorizer")
+	logger := common.RequestLogger(r, "external authorizer")
 	logger = logger.WithField("user", userinfo)
 	authorizationUserInfo := e.getUserInfo(r, userinfo)
 

--- a/common/settings.go
+++ b/common/settings.go
@@ -169,7 +169,7 @@ func validAccessTokenAuthn(AccessTokenAuthnEnabledEnv bool, AccessTokenAuthnEnv 
 		return true
 	}
 
-	log.Info("Please select exactly one of the supported options: " +
+	log.Warn("Please select exactly one of the supported options: " +
 	"i) jwt: to enable the JWT access token authentication method, " +
 	"ii) opaque: to enable the opaque access token authentication method")
 
@@ -186,7 +186,7 @@ func validSessionStoreType(SessionStoreType string) (bool){
 		return true
 	}
 
-	log.Info("Please select exactly one of the options: " +
+	log.Warn("Please select exactly one of the options: " +
 	"i) boltdb: to select the BoltDB supported session store, " +
 	"ii) redis: to select the Redis supported session store")
 

--- a/common/settings.go
+++ b/common/settings.go
@@ -32,6 +32,7 @@ type Config struct {
 	AfterLoginURL        *url.URL `split_words:"true"`
 	AfterLogoutURL       *url.URL `split_words:"true"`
 	VerifyAuthURL        *url.URL `split_words:"true"`
+	LogLevel             string   `split_words:"true" default:"INFO"`
 
 	// Identity Headers
 	UserIDHeader      string            `split_words:"true" default:"kubeflow-userid" envconfig:"USERID_HEADER"`
@@ -108,6 +109,10 @@ func ParseConfig() (*Config, error) {
 	if !validSessionStoreType(c.SessionStoreType){
 		log.Fatalf("Unsupported value for the type of the session store:" +
 			"SESSION_STORE_TYPE=%s",c.SessionStoreType)
+	}
+	if !validLogLevel(c.LogLevel){
+		log.Fatalf("Unsupported value for the log level messages:" +
+		"LOG_LEVEL=%s",c.LogLevel)
 	}
 	c.UserTemplateContext = getEnvsFromPrefix("TEMPLATE_CONTEXT_")
 
@@ -189,6 +194,31 @@ func validSessionStoreType(SessionStoreType string) (bool){
 	log.Warn("Please select exactly one of the options: " +
 	"i) boltdb: to select the BoltDB supported session store, " +
 	"ii) redis: to select the Redis supported session store")
+
+	return false
+}
+
+// validLogLevel() examines if the admins have configured a valid value for the
+// LOG_LEVEL envvar.
+func validLogLevel(level string) bool {
+	if level == "FATAL" {
+		return true
+	} else if level == "ERROR" {
+		return true
+	} else if level == "WARN" {
+		return true
+	} else if level == "INFO" {
+		return true
+	} else if level == "DEBUG" {
+		return true
+	}
+
+	log.Warn("Please select exactly one of the options for the LOG_LEVEL: " +
+	"i) FATAL: to print fatal log level messages, " +
+	"ii) ERROR: to print error log level messages and above, " +
+	"iii) WARN: to print warn log level messages and above, " +
+	"iv) INFO: to print info log level messages and above, " +
+	"v) DEBUG: to pring messages of all the available log levels")
 
 	return false
 }

--- a/common/util.go
+++ b/common/util.go
@@ -57,12 +57,16 @@ func RealPath(path string) (string, error) {
 	return path, nil
 }
 
-func LoggerForRequest(r *http.Request, info string) *log.Entry {
+func RequestLogger(r *http.Request, info string) *log.Entry {
 	return log.WithContext(r.Context()).WithFields(log.Fields{
 		"context": info, // include info about the module generating the log
 		"ip":      getUserIP(r),
 		"request": r.URL.String(),
 	})
+}
+
+func StandardLogger() *log.Logger {
+	return log.StandardLogger()
 }
 
 func getUserIP(r *http.Request) string {

--- a/common/util.go
+++ b/common/util.go
@@ -69,6 +69,20 @@ func StandardLogger() *log.Logger {
 	return log.StandardLogger()
 }
 
+func SetLogLevel(level string) {
+	if level =="FATAL" {
+		log.SetLevel(log.FatalLevel)
+	} else if level == "ERROR" {
+		log.SetLevel(log.ErrorLevel)
+	} else if level == "WARN" {
+		log.SetLevel(log.WarnLevel)
+	} else if level == "INFO" {
+		log.SetLevel(log.InfoLevel)
+	} else {
+		log.SetLevel(log.DebugLevel)
+	}
+}
+
 func getUserIP(r *http.Request) string {
 	headerIP := r.Header.Get("X-Forwarded-For")
 	if headerIP != "" {

--- a/main.go
+++ b/main.go
@@ -33,6 +33,9 @@ func main() {
 	}
 	log.Infof("Config: %+v", c)
 
+	// Set log level
+	common.SetLogLevel(c.LogLevel)
+
 	// Start readiness probe immediately
 	log.Infof("Starting readiness probe at %v", c.ReadinessProbePort)
 	isReady := abool.New()

--- a/main.go
+++ b/main.go
@@ -17,7 +17,6 @@ import (
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	"github.com/patrickmn/go-cache"
-	log "github.com/sirupsen/logrus"
 	"github.com/tevino/abool"
 	"golang.org/x/oauth2"
 	clientconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -26,6 +25,7 @@ import (
 const CacheCleanupInterval = 10
 
 func main() {
+	log := common.StandardLogger()
 
 	c, err := common.ParseConfig()
 	if err != nil {

--- a/oidc/oidc.go
+++ b/oidc/oidc.go
@@ -13,7 +13,6 @@ import (
 	"github.com/arrikto/oidc-authservice/common"
 	"github.com/coreos/go-oidc"
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 )
 
@@ -45,6 +44,8 @@ func NewConfig(clientID string) *oidc.Config {
 }
 
 func NewProvider(ctx context.Context, u *url.URL) Provider {
+	log := common.StandardLogger()
+
 	var provider Provider
 	var err error
 

--- a/oidc/revoke.go
+++ b/oidc/revoke.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/arrikto/oidc-authservice/common"
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 )
 
@@ -33,6 +32,8 @@ func RevocationEndpoint(p Provider) (string, error) {
 // RevokeTokens is a helper that takes an oauth2.Token and revokes the access and refresh tokens.
 // If no tokens are found, it succeeds.
 func RevokeTokens(ctx context.Context, revocationEndpoint string, token *oauth2.Token, clientID, clientSecret string) error {
+	log := common.StandardLogger()
+
 	if token.RefreshToken != "" {
 		log.Info("Attempting to revoke refresh token...")
 		err := revokeToken(ctx, revocationEndpoint, token.RefreshToken, "refresh_token", clientID, clientSecret)

--- a/server.go
+++ b/server.go
@@ -121,7 +121,7 @@ func (s *server) authenticate_no_login(w http.ResponseWriter, r *http.Request) {
 // * authenticate_or_login()
 func (s *server) authenticate(w http.ResponseWriter, r *http.Request, promptLogin bool) (user.Info, bool) {
 
-	logger := common.LoggerForRequest(r, logModuleInfo)
+	logger := common.RequestLogger(r, logModuleInfo)
 	logger.Info("Authenticating request...")
 
 	// Try each one of the available enabled authenticators, if none of them
@@ -165,7 +165,7 @@ func (s *server) authenticate(w http.ResponseWriter, r *http.Request, promptLogi
 // then it will return their user Info and all the other authenticator will be
 // skipped.
 func (s *server) tryAuthenticators(w http.ResponseWriter, r *http.Request, promptLogin bool) (user.Info, bool) {
-	logger := common.LoggerForRequest(r, logModuleInfo)
+	logger := common.RequestLogger(r, logModuleInfo)
 
 	var userInfo user.Info
 	for i, auth := range s.authenticators {
@@ -232,7 +232,7 @@ func (s *server) tryAuthenticators(w http.ResponseWriter, r *http.Request, promp
 // does not allow the user to make the request then AuthService denies the access
 // to this resource.
 func (s *server) authorized(w http.ResponseWriter, r *http.Request, userInfo user.Info) bool {
-	logger := common.LoggerForRequest(r, logModuleInfo)
+	logger := common.RequestLogger(r, logModuleInfo)
 
 	for _, authz := range s.authorizers {
 		allowed, reason, err := authz.Authorize(r, userInfo)
@@ -275,7 +275,7 @@ func (s *server) authorized(w http.ResponseWriter, r *http.Request, userInfo use
 // if there is an entry in the cache for the examined user.
 // Otherwise, it returns an empty string for the cacheKey and nil respectively.
 func (s *server) getCachedUser(auth authenticators.AuthenticatorRequest, r *http.Request) (user.Info, string) {
-	logger := common.LoggerForRequest(r, logModuleInfo)
+	logger := common.RequestLogger(r, logModuleInfo)
 
 	// If the cache is enabled, check if the current authenticator implements the Cacheable interface.
 	cacheable := reflect.TypeOf((*authenticators.Cacheable)(nil)).Elem()
@@ -305,7 +305,7 @@ func (s *server) getCachedUser(auth authenticators.AuthenticatorRequest, r *http
 
 // authCodeFlowAuthenticationRequest initiates an OIDC Authorization Code flow
 func (s *server) authCodeFlowAuthenticationRequest(w http.ResponseWriter, r *http.Request) {
-	logger := common.LoggerForRequest(r, logModuleInfo)
+	logger := common.RequestLogger(r, logModuleInfo)
 
 	// Initiate OIDC Flow with Authorization Request.
 	state, err := sessions.CreateState(r, w, s.oidcStateStore)
@@ -321,7 +321,7 @@ func (s *server) authCodeFlowAuthenticationRequest(w http.ResponseWriter, r *htt
 // callback is the handler responsible for exchanging the auth_code and retrieving an id_token.
 func (s *server) callback(w http.ResponseWriter, r *http.Request) {
 
-	logger := common.LoggerForRequest(r, logModuleInfo)
+	logger := common.RequestLogger(r, logModuleInfo)
 
 	// Get authorization code from authorization response.
 	var authCode = r.FormValue("code")
@@ -465,7 +465,7 @@ func (s *server) enabledAuthenticator(authenticator string) bool {
 // logout is the handler responsible for revoking the user's session.
 func (s *server) logout(w http.ResponseWriter, r *http.Request) {
 
-	logger := common.LoggerForRequest(r, logModuleInfo)
+	logger := common.RequestLogger(r, logModuleInfo)
 
 	// Only header auth allowed for this endpoint
 	sessionID := common.GetBearerToken(r.Header.Get(s.authHeader))
@@ -539,7 +539,7 @@ func readiness(isReady *abool.AtomicBool) http.HandlerFunc {
 func (s *server) whitelistMiddleware(whitelist []string, isReady *abool.AtomicBool, verify bool) func(http.Handler) http.Handler {
 	return func(handler http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			logger := common.LoggerForRequest(r, logModuleInfo)
+			logger := common.RequestLogger(r, logModuleInfo)
 
 			path := r.URL.Path
 			// If called by the `/authservice/verify` router then

--- a/server.go
+++ b/server.go
@@ -184,12 +184,12 @@ func (s *server) tryAuthenticators(w http.ResponseWriter, r *http.Request, promp
 
 			if userInfo != nil {
 				logger.Infof("Successfully authenticated request using the cache.")
-				logger.Infof("UserInfo: %+v", userInfo)
+				logger.Debugf("UserInfo: %+v", userInfo)
 				return userInfo, true
 			}
 		}
 
-		logger.Infof("%s starting...", strings.Title(authenticatorsMapping[i]))
+		logger.Debugf("%s starting...", strings.Title(authenticatorsMapping[i]))
 		resp, found, err := auth.AuthenticateRequest(r)
 		if err != nil {
 			logger.Errorf("Error authenticating request using %s: %v", authenticatorsMapping[i], err)
@@ -215,11 +215,11 @@ func (s *server) tryAuthenticators(w http.ResponseWriter, r *http.Request, promp
 		if found {
 			logger.Infof("Successfully authenticated request using %s", authenticatorsMapping[i])
 			userInfo = resp.User
-			logger.Infof("UserInfo: %+v", userInfo)
+			logger.Debugf("UserInfo: %+v", userInfo)
 
 			if s.cacheEnabled && cacheKey != "" && promptLogin {
 				// If cache is enabled and the current authenticator is Cacheable, store the UserInfo to cache.
-				logger.Infof("Caching authenticated UserInfo...")
+				logger.Debugf("Caching authenticated UserInfo...")
 				s.bearerUserInfoCache.Set(cacheKey, userInfo, time.Duration(s.cacheExpirationMinutes)*time.Minute)
 			}
 			return userInfo, true
@@ -292,14 +292,14 @@ func (s *server) getCachedUser(auth authenticators.AuthenticatorRequest, r *http
 			cachedUserInfo, found := s.bearerUserInfoCache.Get(cacheKey)
 			if found {
 				userInfo := cachedUserInfo.(user.Info)
-				logger.Infof("Found Cached UserInfo: %+v", userInfo)
+				logger.Debugf("Found Cached UserInfo: %+v", userInfo)
 				return userInfo, cacheKey
 			}
 			return nil, cacheKey
 		}
 	}
 
-	logger.Info("The UserInfo is not cached.")
+	logger.Debug("The UserInfo is not cached.")
 	return nil, ""
 }
 
@@ -551,7 +551,7 @@ func (s *server) whitelistMiddleware(whitelist []string, isReady *abool.AtomicBo
 			// Check whitelist
 			for _, prefix := range whitelist {
 				if strings.HasPrefix(path, prefix) {
-					logger.Infof("URI is whitelisted. Accepted without authorization.")
+					logger.Debugf("URI is whitelisted. Accepted without authorization.")
 					if verify {
 						w.WriteHeader(http.StatusNoContent)
 					} else {

--- a/sessions/redis.go
+++ b/sessions/redis.go
@@ -2,14 +2,15 @@ package sessions
 
 import (
 	"context"
-	"log"
 
+	"github.com/arrikto/oidc-authservice/common"
 	"github.com/go-redis/redis/v8"
 	"github.com/rbcervilla/redisstore/v8"
 )
 
 
 func newRedisSessionStore(addr, password, keyPrefix string, db int) (*redisstore.RedisStore, error) {
+	log := common.StandardLogger()
 
 	client := redis.NewClient(&redis.Options{
 		Addr: addr,

--- a/sessions/session.go
+++ b/sessions/session.go
@@ -65,15 +65,15 @@ func SessionFromRequest(r *http.Request, store sessions.Store, cookie,
 	if sessionID != "" {
 		s, err := SessionFromID(sessionID, store)
 		if err == nil && !s.IsNew {
-			logger.Infof("Loading session from header %s", header)
+			logger.Debugf("Loading session from header %s", header)
 			// Authentication using header successfully completed
 			authMethod = "header"
 			return s, authMethod, nil
 		}
-		logger.Infof("Header %s didn't contain a valid session id: %v", header, err)
+		logger.Debugf("Header %s didn't contain a valid session id: %v", header, err)
 	}
 	// Header failed, try to get session from cookie
-	logger.Infof("Loading session from cookie %s", cookie)
+	logger.Debugf("Loading session from cookie %s", cookie)
 	s, err := store.Get(r, cookie)
 	if err == nil && !s.IsNew {
 		authMethod = "cookie"

--- a/sessions/session.go
+++ b/sessions/session.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gorilla/sessions"
 	"github.com/pkg/errors"
 	"github.com/yosssi/boltstore/shared"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 )
 
@@ -60,7 +59,7 @@ func SessionFromRequest(r *http.Request, store sessions.Store, cookie,
 	header string) (*sessions.Session, string, error) {
 
 	var authMethod string
-	logger := common.LoggerForRequest(r, "session authenticator")
+	logger := common.RequestLogger(r, "session authenticator")
 	// Try to get session from header
 	sessionID := common.GetBearerToken(r.Header.Get(header))
 	if sessionID != "" {
@@ -107,7 +106,7 @@ func RevokeOIDCSession(ctx context.Context, w http.ResponseWriter,
 	session *sessions.Session, provider oidc.Provider,
 	oauth2Config *oauth2.Config, caBundle []byte) error {
 
-	logger := logrus.StandardLogger()
+	logger := common.StandardLogger()
 
 	// Revoke the session's OAuth tokens
 	_revocationEndpoint, err := oidc.RevocationEndpoint(provider)
@@ -133,7 +132,7 @@ func RevokeOIDCSession(ctx context.Context, w http.ResponseWriter,
 // return these two session stores, or will terminate the execution with a fatal
 // log message.
 func InitiateSessionStores(c *common.Config) (ClosableStore, ClosableStore) {
-	logger := logrus.StandardLogger()
+	logger := common.StandardLogger()
 
 	var store, oidcStateStore ClosableStore
 	var err error

--- a/web_server.go
+++ b/web_server.go
@@ -89,7 +89,7 @@ func (s *WebServer) Start(addr string) error {
 // siteHandler returns an http.HandlerFunc that serves a given template
 func siteHandler(tmpl *template.Template, data interface{}) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		logger := common.LoggerForRequest(r, "web server")
+		logger := common.RequestLogger(r, "web server")
 		if err := tmpl.Execute(w, data); err != nil {
 			logger.Errorf("Error executing template: %v", err)
 		}


### PR DESCRIPTION
During live debug sessions we realized that the AuthService logs are way too verbose and thus not helpful for debugging. Since all requests are passed through AuthService for authentication we have a chunk of logs for every one of the requests, even for requests to whitelisted URLs.

#### Related upstream PR
As you can see in the repo there is an upstream PR which dates back to 2019 (https://github.com/arrikto/oidc-authservice/pull/3). This PR introduces a new `LOG_LEVEL` envvar that expects one of the following values:
* `warn`
* `info`
* `debug`

The functionality that the contributor has added seems to be in the right direction. But a lot has changed since they submitted this PR. So we had better start fresh and lay out a plan that complies with the latest `oidc-authservice`.

## Proposed Plan

We need to **re-categorize** our log messages in the available log level categories. Right now the log level which we use in `oidc-authservice` are:
* `fatal`
* `error`
* `warn`
* `info`
* `debug`

The current log messages that belong to either one of the first three log levels should remain in these log levels. The same goes for the log messages that belong to the `debug` log level.

The **challenge** is to revise the log messages of the `info` log level which is currently way too **verbose** and leads to unreadable logs. The plan is to distinguish which of the `info` log messages should belong to the `debug` log level instead. As we will expose later on, we will also transfer a few settings-related `info` logs to the `warn` log level.

#### Good to have

It would be beneficial to isolate the dependency to the `"github.com/siroupsen/logrus"` (https://github.com/sirupsen/logrus) package inside the `common` package. For this we will need a new and simple function that sets up a `StandardLogger()`:
```go
func LoggerStandard() *log.Logger {
	return log.StandardLogger()
}
```
This will make our code more maintainable and also it will allow us to enforce a single log level across our code.

#### Regarding the order of the log levels

As exposed in the `README.md` of the `"github.com/sirupsen/logrus"` library (https://github.com/sirupsen/logrus):
> You can set the logging level on a Logger, then it will only log entries with that severity or anything above it:
> // Will log anything that is info or above (warn, error, fatal, panic). Default.
>  ```golang 
>     log.SetLevel(log.InfoLevel)
>  ```
> It may be useful to set log.Level = logrus.DebugLevel in a debug or verbose environment if your application has that.

From this I deduce that the ordering is:
1. `panic` (we have no such log message in AuthService)
2. `fatal`
3. `error`
4. `warn`
5. `info`
6. `debug`

Setting the log level to the i-th item means that all the log messages that belong to the {1, .., i} set will be logged. If a log message belongs to {i+1, ..., 6} then it will not be logged. So the bigger the configured log level is, the more verbose the logs of AuthService will be.

Let's default to `info` log level.

## Testing

I made a rather simple test to quantify the impact of these changes in the AuthService logs. The 5-minute experiment I did was the following:
1. start AuthService pod (0:00)
2. login as `user@example.com` (2:00)
3. keep the UI as an active browser window
4. logout (4:00)
5. stop the AuthService logs

I did this for both an old and the new image. The comparison is:
* old image logged **452 lines**
* new image logged **70 lines**.

Thanks for your time!