### PR TITLE
Update access and refresh tokens in session

### DIFF
--- a/authenticators/opaque.go
+++ b/authenticators/opaque.go
@@ -37,7 +37,9 @@ func (s *OpaqueTokenAuthenticator) AuthenticateRequest(r *http.Request) (*authen
 
 	ctx := common.SetTLSContext(r.Context(), s.CaBundle)
 
-	userInfo, err := oidc.GetUserInfo(ctx, s.Provider, s.Oauth2Config.TokenSource(ctx, opaque))
+	newToken, _, err := oidc.TokenSource(ctx, s.Oauth2Config, opaque)
+
+	userInfo, err := oidc.GetUserInfo(ctx, s.Provider, newToken)
 	if err != nil {
 		var reqErr *common.RequestError
 		if !errors.As(err, &reqErr) {

--- a/oidc/oidc_test.go
+++ b/oidc/oidc_test.go
@@ -115,7 +115,7 @@ func TestGetUserInfo_ContextCancelled(t *testing.T) {
 
 	// Make a UserInfo request
 	_, err = GetUserInfo(context.Background(), provider,
-		oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test"}))
+		&oauth2.Token{AccessToken: "test"})
 
 	// Check that we find a wrapped requestError
 	var reqErr *common.RequestError

--- a/server.go
+++ b/server.go
@@ -379,14 +379,16 @@ func (s *server) callback(w http.ResponseWriter, r *http.Request) {
 
 	// UserInfo endpoint to get claims
 	claims := map[string]interface{}{}
-	oidcUserInfo, err := oidc.GetUserInfo(ctx, s.provider, s.oauth2Config.TokenSource(ctx, oauth2Tokens))
+
+	newTokens, _, err := oidc.TokenSource(ctx, s.oauth2Config, oauth2Tokens)
+	userInfo, err := oidc.GetUserInfo(ctx, s.provider, newTokens)
 	if err != nil {
 		logger.Errorf("Not able to fetch userinfo: %v", err)
 		common.ReturnMessage(w, http.StatusInternalServerError, "Not able to fetch userinfo.")
 		return
 	}
 
-	if err = oidcUserInfo.Claims(&claims); err != nil {
+	if err = userInfo.Claims(&claims); err != nil {
 		logger.Errorf("Problem getting userinfo claims: %v", err)
 		common.ReturnMessage(w, http.StatusInternalServerError, "Not able to fetch userinfo claims.")
 		return


### PR DESCRIPTION
This PR introduces the following changes:
* Update access and refresh tokens in session if the ones stored in db have expired and been refreshed.
* Trigger the session update regardless of strict validation mode to ensure token validity.

The above will eliminate unnecessary requests to the OIDC provider.

Signed-off-by: Athina Plaskasoviti <athinapl@arrikto.com>